### PR TITLE
Add Ionic starter for JHipster

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "ionic-angular/community/danielsogl/super"]
 	path = ionic-angular/community/danielsogl/super
 	url = https://github.com/danielsogl/ionic-super-starter.git
+[submodule "ionic-angular/community/oktadeveloper/jhipster"]
+	path = ionic-angular/community/oktadeveloper/jhipster
+	url = https://github.com/oktadeveloper/ionic-jhipster-starter.git


### PR DESCRIPTION
I'm not sure this has to be in this repository, but it seems to be the only way to run `ionic start myApp oktadeveloper/jhipster`. If there's another way to run that command and pull from https://github.com/oktadeveloper/ionic-jhipster-starter, I'd love to hear about it!