### PR TITLE
Fix HTTP GET request params modification

### DIFF
--- a/ionic-angular/official/super/src/providers/api/api.ts
+++ b/ionic-angular/official/super/src/providers/api/api.ts
@@ -22,7 +22,7 @@ export class Api {
     if (params) {
       reqOpts.params = new HttpParams();
       for (let k in params) {
-        reqOpts.params.set(k, params[k]);
+        reqOpts.params = reqOpts.params.set(k, params[k]);
       }
     }
 


### PR DESCRIPTION
HttpParams class is immutable - all mutation operations return a new instance.
@see https://angular.io/api/common/http/HttpParams