### PR TITLE
propose: add page.module.ts

### DIFF
--- a/angular/official/blank/src/app/app.module.ts
+++ b/angular/official/blank/src/app/app.module.ts
@@ -3,19 +3,18 @@ import { BrowserModule } from '@angular/platform-browser';
 import { IonicAngularModule } from '@ionic/angular';
 
 import { AppComponent } from './app.component';
-import { HomePage } from './pages/home/home.page';
+import { PagesModule } from './pages/pages.module';
 
 @NgModule({
   declarations: [
     AppComponent,
-    HomePage,
   ],
   entryComponents: [
-    HomePage,
   ],
   imports: [
     BrowserModule,
     IonicAngularModule.forRoot(),
+    PagesModule,
   ],
   providers: [],
   bootstrap: [AppComponent],

--- a/angular/official/blank/src/app/pages/home/home.page.scss
+++ b/angular/official/blank/src/app/pages/home/home.page.scss
@@ -1,3 +1,1 @@
-app-page-home {
 
-}

--- a/angular/official/blank/src/app/pages/home/home.page.scss
+++ b/angular/official/blank/src/app/pages/home/home.page.scss
@@ -1,1 +1,3 @@
-// homepage styles
+app-page-home {
+
+}

--- a/angular/official/blank/src/app/pages/pages.module.ts
+++ b/angular/official/blank/src/app/pages/pages.module.ts
@@ -1,0 +1,19 @@
+import { CUSTOM_ELEMENTS_SCHEMA, NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { IonicAngularModule } from '@ionic/angular';
+import { HomePage } from './home/home.page';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    IonicAngularModule.forRoot(),
+  ],
+  declarations: [
+      HomePage,
+  ],
+  entryComponents: [
+      HomePage
+  ],
+  schemas: [CUSTOM_ELEMENTS_SCHEMA],
+})
+export class PagesModule { }


### PR DESCRIPTION
Angular CLI can't judge `pages` and check `@angular/router`.
So I think Ionic CLI's `page` concentrate page.module.ts. and match selector name. ex) `app-page-home`

fix https://github.com/ionic-team/ionic-cli/issues/3019#issuecomment-375595052