### PR TITLE
chore(cordova): increase android-minSdkVersion from 16 to 19

### DIFF
--- a/integrations/cordova/config.xml
+++ b/integrations/cordova/config.xml
@@ -12,7 +12,7 @@
     <allow-intent href="mailto:*" />
     <allow-intent href="geo:*" />
     <preference name="ScrollEnabled" value="false" />
-    <preference name="android-minSdkVersion" value="16" />
+    <preference name="android-minSdkVersion" value="19" />
     <preference name="BackupWebStorage" value="none" />
     <preference name="SplashMaintainAspectRatio" value="true" />
     <preference name="FadeSplashScreenDuration" value="300" />


### PR DESCRIPTION
Run with current Cordova tooling (Cordova CLI 8.0.0, Cordova Android 7.1.0) you currently get this error on build:

```
[cordova]
[cordova] :app:processDebugManifest FAILED
[cordova]       uses-sdk:minSdkVersion 16 cannot be smaller than version 19 declared in library [:CordovaLib] C:\Projects\Ionic Demo Projects\ionic-cordova-push-onesignal\platforms\android\CordovaLib\build\intermediates\manifests\full\debug\AndroidManifest.xml as the library might be using APIs not available in 16
[cordova]       Suggestion: use a compatible library with a minSdk of at most 16,
[cordova]               or increase this project's minSdk version to at least 19,
[cordova]               or use tools:overrideLibrary="org.apache.cordova" to force usage (may lead to runtime failures)
[cordova]
[cordova] FAILURE: Build failed with an exception.
```

Increasing the `android-minSdkVersion` to `19` as suggested fixes the problem.