### PR TITLE
fix(sidemenu): menu navigations are root

### DIFF
--- a/angular/official/sidemenu/src/app/app.component.html
+++ b/angular/official/sidemenu/src/app/app.component.html
@@ -19,6 +19,6 @@
         </ion-list>
       </ion-content>
     </ion-menu>
-    <ion-router-outlet main></ion-router-outlet>
+    <ion-router-outlet main animated='false'></ion-router-outlet>
   </ion-split-pane>
 </ion-app>

--- a/angular/official/sidemenu/src/app/app.component.html
+++ b/angular/official/sidemenu/src/app/app.component.html
@@ -9,7 +9,7 @@
       <ion-content>
         <ion-list>
           <ion-menu-toggle auto-hide="false" *ngFor="let p of appPages">
-            <ion-item [routerLink]="[p.url]">
+            <ion-item [routerDirection]="'root'" [routerLink]="[p.url]">
               <ion-icon slot="start" [name]="p.icon"></ion-icon>
               <ion-label>
                 {{p.title}}
@@ -19,6 +19,6 @@
         </ion-list>
       </ion-content>
     </ion-menu>
-    <ion-router-outlet main animated='false'></ion-router-outlet>
+    <ion-router-outlet main></ion-router-outlet>
   </ion-split-pane>
 </ion-app>

--- a/angular/official/sidemenu/src/app/pages/list/list.page.html
+++ b/angular/official/sidemenu/src/app/pages/list/list.page.html
@@ -2,7 +2,6 @@
   <ion-toolbar>
     <ion-buttons slot="start">
       <ion-menu-button></ion-menu-button>
-      <ion-back-button ></ion-back-button>
     </ion-buttons>
     <ion-title>
       Ionic Blank


### PR DESCRIPTION
This PR fixes two things:
`
1. Removes the ion-back-button on the list page (we might have to add this back when list navigation is implemented, not totally sure at the moment)
2. Navigations from the sidemenu now are `root` navigations so that they work just like they did in v3