### PR TITLE
Fix(angular/polyfills): correspond Fetch as Google

### DIFF
--- a/angular/base/src/polyfills.ts
+++ b/angular/base/src/polyfills.ts
@@ -28,7 +28,7 @@
 // import 'core-js/es6/math';
 // import 'core-js/es6/string';
 // import 'core-js/es6/date';
-// import 'core-js/es6/array';
+import 'core-js/es6/array';
 // import 'core-js/es6/regexp';
 // import 'core-js/es6/map';
 // import 'core-js/es6/weak-map';


### PR DESCRIPTION
`Fetch as Google` (Google's bot checker) use ES5. So require polyfills (`Fetch as Google` need at least `core-js/es6/array` ).

I think that Ionic needs a response to Google in order to become a PWA.