### PR TITLE
chore(tslint): allow component-selector "page-**"

### DIFF
--- a/angular/base/tslint.json
+++ b/angular/base/tslint.json
@@ -122,6 +122,7 @@
       true,
       "element",
       "app",
+      "page",
       "kebab-case"
     ],
     "no-output-on-prefix": true,


### PR DESCRIPTION
If migrate v3 to v4, all page component name is "page-*". So I think this is no need to change everything.