### PR TITLE
fix(angular/tabs): redirect `example.com/tabs/` to (home:home)

### DIFF
--- a/angular/official/tabs/src/app/tabs/tabs.router.module.ts
+++ b/angular/official/tabs/src/app/tabs/tabs.router.module.ts
@@ -12,6 +12,11 @@ const routes: Routes = [
     component: TabsPage,
     children: [
       {
+        path: '',
+        redirectTo: '/tabs/(home:home)',
+        pathMatch: 'full',
+      },
+      {
         path: 'home',
         outlet: 'home',
         component: HomePage


### PR DESCRIPTION
example.com redirect `example.com/tabs/(home:home)` . but `example.com/tabs` display blank page. so add redirect.