### PR TITLE
fix(angular/css) update css references based on 4.0.0-beta.6 changes

### DIFF
--- a/angular/base/package.json
+++ b/angular/base/package.json
@@ -23,7 +23,7 @@
     "@ionic-native/core": "5.0.0-beta.15",
     "@ionic-native/splash-screen": "5.0.0-beta.15",
     "@ionic-native/status-bar": "5.0.0-beta.15",
-    "@ionic/angular": "4.0.0-beta.5",
+    "@ionic/angular": "4.0.0-beta.7",
     "core-js": "^2.5.3",
     "rxjs": "6.2.2",
     "zone.js": "^0.8.26"

--- a/angular/base/src/global.scss
+++ b/angular/base/src/global.scss
@@ -1,8 +1,8 @@
 // http://ionicframework.com/docs/theming/
+@import "~@ionic/angular/css/core.css";
 @import "~@ionic/angular/css/normalize.css";
 @import "~@ionic/angular/css/structure.css";
 @import "~@ionic/angular/css/typography.css";
-@import "~@ionic/angular/css/colors.css";
 
 @import "~@ionic/angular/css/padding.css";
 @import "~@ionic/angular/css/float-elements.css";


### PR DESCRIPTION
My updated package.json
{ "name": "someApp", "version": "0.0.1", "author": "Ionic Framework", "homepage": "http://ionicframework.com/", "scripts": { "ng": "ng", "start": "ng serve", "build": "ng build", "test": "ng test", "lint": "ng lint", "e2e": "ng e2e" }, "private": true, "dependencies": { "@angular/common": "~6.1.1", "@angular/core": "~6.1.1", "@angular/forms": "~6.1.1", "@angular/http": "~6.1.1", "@angular/platform-browser": "~6.1.1", "@angular/platform-browser-dynamic": "~6.1.1", "@angular/router": "~6.1.1", "@ionic-native/core": "5.0.0-beta.15", "@ionic-native/splash-screen": "5.0.0-beta.15", "@ionic-native/status-bar": "5.0.0-beta.15", "@ionic/angular": "^4.0.0-beta.7", "core-js": "^2.5.3", "rxjs": "^6.3.0", "zone.js": "^0.8.26" }, "devDependencies": { "@angular-devkit/architect": "~0.7.2", "@angular-devkit/build-angular": "~0.7.2", "@angular-devkit/core": "~0.7.2", "@angular-devkit/schematics": "~0.7.2", "@angular/cli": "~6.1.1", "@angular/compiler": "~6.1.1", "@angular/compiler-cli": "~6.1.1", "@angular/language-service": "~6.1.1", "@ionic/ng-toolkit": "^1.0.0", "@ionic/schematics-angular": "^1.0.0", "@types/jasmine": "~2.8.6", "@types/jasminewd2": "~2.0.3", "@types/node": "~10.9.2", "codelyzer": "~4.4.2", "jasmine-core": "^3.2.1", "jasmine-spec-reporter": "~4.2.1", "karma": "~3.0.0", "karma-chrome-launcher": "~2.2.0", "karma-coverage-istanbul-reporter": "~2.0.0", "karma-jasmine": "~1.1.1", "karma-jasmine-html-reporter": "^1.3.1", "protractor": "~5.4.0", "ts-node": "~7.0.0", "tslint": "~5.11.0", "typescript": "^2.9.2" }, "description": "An Ionic project" }

Package.json: [https://pastebin.com/HYKGu1zZ](https://pastebin.com/HYKGu1zZ)