### PR TITLE
fix(ionic1): rm window.Keyboard.hideKeyboardAccessoryBar call

### DIFF
--- a/ionic1/base/www/js/app.js
+++ b/ionic1/base/www/js/app.js
@@ -7,16 +7,6 @@ angular.module('starter', ['ionic'])
 
 .run(function($ionicPlatform) {
   $ionicPlatform.ready(function() {
-    // Hide the accessory bar by default (remove this to show the accessory bar above the keyboard
-    // for form inputs).
-    // The reason we default this to hidden is that native apps don't usually show an accessory bar, at
-    // least on iOS. It's a dead giveaway that an app is using a Web View. However, it's sometimes
-    // useful especially with forms, though we would prefer giving the user a little more room
-    // to interact with the app.
-    if (window.cordova && window.Keyboard) {
-      window.Keyboard.hideKeyboardAccessoryBar(true);
-    }
-
     if (window.StatusBar) {
       // Set the statusbar to use the default style, tweak this to
       // remove the status bar on iOS or change it to use white instead of dark colors.

--- a/ionic1/official/blank/www/js/app.js
+++ b/ionic1/official/blank/www/js/app.js
@@ -7,16 +7,6 @@ angular.module('starter', ['ionic'])
 
 .run(function($ionicPlatform) {
   $ionicPlatform.ready(function() {
-    // Hide the accessory bar by default (remove this to show the accessory bar above the keyboard
-    // for form inputs).
-    // The reason we default this to hidden is that native apps don't usually show an accessory bar, at
-    // least on iOS. It's a dead giveaway that an app is using a Web View. However, it's sometimes
-    // useful especially with forms, though we would prefer giving the user a little more room
-    // to interact with the app.
-    if (window.cordova && window.Keyboard) {
-      window.Keyboard.hideKeyboardAccessoryBar(true);
-    }
-
     if (window.StatusBar) {
       // Set the statusbar to use the default style, tweak this to
       // remove the status bar on iOS or change it to use white instead of dark colors.

--- a/ionic1/official/sidemenu/www/js/app.js
+++ b/ionic1/official/sidemenu/www/js/app.js
@@ -8,16 +8,6 @@ angular.module('starter', ['ionic', 'starter.controllers'])
 
 .run(function($ionicPlatform) {
   $ionicPlatform.ready(function() {
-    // Hide the accessory bar by default (remove this to show the accessory bar above the keyboard
-    // for form inputs).
-    // The reason we default this to hidden is that native apps don't usually show an accessory bar, at
-    // least on iOS. It's a dead giveaway that an app is using a Web View. However, it's sometimes
-    // useful especially with forms, though we would prefer giving the user a little more room
-    // to interact with the app.
-    if (window.cordova && window.Keyboard) {
-      window.Keyboard.hideKeyboardAccessoryBar(true);
-    }
-
     if (window.StatusBar) {
       // Set the statusbar to use the default style, tweak this to
       // remove the status bar on iOS or change it to use white instead of dark colors.

--- a/ionic1/official/tabs/www/js/app.js
+++ b/ionic1/official/tabs/www/js/app.js
@@ -9,16 +9,6 @@ angular.module('starter', ['ionic', 'starter.controllers', 'starter.services'])
 
 .run(function($ionicPlatform) {
   $ionicPlatform.ready(function() {
-    // Hide the accessory bar by default (remove this to show the accessory bar above the keyboard
-    // for form inputs).
-    // The reason we default this to hidden is that native apps don't usually show an accessory bar, at
-    // least on iOS. It's a dead giveaway that an app is using a Web View. However, it's sometimes
-    // useful especially with forms, though we would prefer giving the user a little more room
-    // to interact with the app.
-    if (window.cordova && window.Keyboard) {
-      window.Keyboard.hideKeyboardAccessoryBar(true);
-    }
-
     if (window.StatusBar) {
       // Set the statusbar to use the default style, tweak this to
       // remove the status bar on iOS or change it to use white instead of dark colors.


### PR DESCRIPTION
I don't know if just removing this is the correct thing to do but for whatever reason when I start from a fresh ionic 1 starter I get this error
```
TypeError: window.Keyboard.hideKeyboardAccessoryBar is not a function. (In 'window.Keyboard.hideKeyboardAccessoryBar(true)', 'window.Keyboard.hideKeyboardAccessoryBar' is undefined)
```
Not sure if the proper fix is changing some version of the plugin or what but this fixed locally. The issue was discovered when a user opened an issue that Ionic Deploy wasn't working with Ionic 1. Ionic Deploy waits for `document.addEventListener('deviceready', ...)` before initializing and apparently in Ionic 1 this error in the `$ionicPlatform.ready` handler causes that event to be swallowed up for other things listening. As a fix in deploy I listen with a timeout and recreate the listener if `deviceready` hasn't fired within a couple hundred milliseconds and the subsequent listener gets the event. However this may affect other things trying to listen for `deviceready` as well so should probably be addressed one way or the other.