### PR TITLE
fix(angular): add correct coverage report path

### DIFF
--- a/angular/base/src/karma.conf.js
+++ b/angular/base/src/karma.conf.js
@@ -16,7 +16,7 @@ module.exports = function (config) {
       clearContext: false // leave Jasmine Spec Runner output visible in browser
     },
     coverageIstanbulReporter: {
-      dir: require('path').join(__dirname, 'coverage'),
+      dir: require('path').join(__dirname, '../coverage'),
       reports: ['html', 'lcovonly'],
       fixWebpackSourcePaths: true
     },


### PR DESCRIPTION
Actually the coverage report will be created inside the `src` folder and not outside of it.