### PR TITLE
fix(ionic-angular): Add support for environment feature

### DIFF
--- a/ionic-angular/base/src/declarations.d.ts
+++ b/ionic-angular/base/src/declarations.d.ts
@@ -1,0 +1,1 @@
+declare var process: { env: { [key: string]: string | undefined; } };

--- a/ionic-angular/base/tsconfig.json
+++ b/ionic-angular/base/tsconfig.json
@@ -11,7 +11,8 @@
     "module": "es2015",
     "moduleResolution": "node",
     "sourceMap": true,
-    "target": "es5"
+    "target": "es5",
+    "types": []
   },
   "include": [
     "src/**/*.ts"


### PR DESCRIPTION
Ionic-app-scripts introduced environment feature in v3.2.0.

Need to add types property in `compilerOptions` to be able to use the environment feature (as explained here: https://github.com/ionic-team/ionic-cli/issues/3541)