### PR TITLE
fix(tabs-starter): follow v4 migration guide

### DIFF
--- a/angular/official/tabs/src/app/contact/contact.page.html
+++ b/angular/official/tabs/src/app/contact/contact.page.html
@@ -8,10 +8,16 @@
 
 <ion-content>
   <ion-list>
-    <ion-list-header>Follow us on Twitter</ion-list-header>
+    <ion-list-header>
+      <ion-label>
+        Follow us on Twitter
+      </ion-label>
+    </ion-list-header>
     <ion-item>
-      <ion-icon name="logo-ionic" slot="start"></ion-icon>
-      @ionicframework
+      <ion-label>
+        <ion-icon name="logo-ionic" slot="start"></ion-icon>
+        @ionicframework
+      </ion-label>
     </ion-item>
   </ion-list>
 </ion-content>


### PR DESCRIPTION
Prior to this modification, the migration linting tool generates errors about missing ion-labels. Kind of embarrassing when using this as a starting point for a migration.  :)