### PR TITLE
fix(): use preloading strategy in all starters

### DIFF
--- a/angular/official/blank/src/app/app-routing.module.ts
+++ b/angular/official/blank/src/app/app-routing.module.ts
@@ -1,5 +1,5 @@
 import { NgModule } from '@angular/core';
-import { Routes, RouterModule } from '@angular/router';
+import { PreloadAllModules, RouterModule, Routes } from '@angular/router';
 
 const routes: Routes = [
   { path: '', redirectTo: 'home', pathMatch: 'full' },
@@ -7,7 +7,9 @@ const routes: Routes = [
 ];
 
 @NgModule({
-  imports: [RouterModule.forRoot(routes)],
+  imports: [
+    RouterModule.forRoot(routes, { preloadingStrategy: PreloadAllModules })
+  ],
   exports: [RouterModule]
 })
 export class AppRoutingModule { }

--- a/angular/official/sidemenu/src/app/app-routing.module.ts
+++ b/angular/official/sidemenu/src/app/app-routing.module.ts
@@ -1,5 +1,5 @@
 import { NgModule } from '@angular/core';
-import { Routes, RouterModule } from '@angular/router';
+import { PreloadAllModules, RouterModule, Routes } from '@angular/router';
 
 const routes: Routes = [
   {
@@ -18,7 +18,9 @@ const routes: Routes = [
 ];
 
 @NgModule({
-  imports: [RouterModule.forRoot(routes)],
+  imports: [
+    RouterModule.forRoot(routes, { preloadingStrategy: PreloadAllModules })
+  ],
   exports: [RouterModule]
 })
 export class AppRoutingModule {}


### PR DESCRIPTION
This PR adds the preloading strategy to the blank and sidemenu starters (it is already there in the tabs starter).
This was discussed in the comments of the recent blog post: 
https://blog.ionicframework.com/how-to-lazy-load-in-ionic-angular/
@elylucas 