### PR TITLE
fix: replace onclick handlers with links for accessibility

### DIFF
--- a/react/official/sidemenu/src/components/Menu.tsx
+++ b/react/official/sidemenu/src/components/Menu.tsx
@@ -11,7 +11,7 @@ import {
   IonToolbar
 } from '@ionic/react';
 import React from 'react';
-import { Link, RouteComponentProps, withRouter } from 'react-router-dom';
+import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { AppPage } from '../declarations';
 
 type MenuProps = RouteComponentProps<{}> & {
@@ -30,12 +30,10 @@ const Menu: React.FunctionComponent<MenuProps> = ({ history, appPages }) => (
         {appPages.map((appPage, index) => {
           return (
             <IonMenuToggle key={index} auto-hide="false">
-              <Link to={appPage.url}>
-                <IonItem>
-                  <IonIcon slot="start" icon={appPage.icon} />
-                  <IonLabel>{appPage.title}</IonLabel>
-                </IonItem>
-              </Link>
+              <IonItem href={appPage.url}>
+                <IonIcon slot="start" icon={appPage.icon} />
+                <IonLabel>{appPage.title}</IonLabel>
+              </IonItem>
             </IonMenuToggle>
           );
         })}

--- a/react/official/sidemenu/src/components/Menu.tsx
+++ b/react/official/sidemenu/src/components/Menu.tsx
@@ -11,7 +11,7 @@ import {
   IonToolbar
 } from '@ionic/react';
 import React from 'react';
-import { RouteComponentProps, withRouter } from 'react-router-dom';
+import { Link, RouteComponentProps, withRouter } from 'react-router-dom';
 import { AppPage } from '../declarations';
 
 type MenuProps = RouteComponentProps<{}> & {
@@ -30,10 +30,12 @@ const Menu: React.FunctionComponent<MenuProps> = ({ history, appPages }) => (
         {appPages.map((appPage, index) => {
           return (
             <IonMenuToggle key={index} auto-hide="false">
-              <IonItem routerDirection="root" onClick={() => history.push(appPage.url)}>
-                <IonIcon slot="start" icon={appPage.icon} />
-                <IonLabel>{appPage.title}</IonLabel>
-              </IonItem>
+              <Link to={appPage.url}>
+                <IonItem>
+                  <IonIcon slot="start" icon={appPage.icon} />
+                  <IonLabel>{appPage.title}</IonLabel>
+                </IonItem>
+              </Link>
             </IonMenuToggle>
           );
         })}

--- a/react/official/tabs/src/pages/Tab2.tsx
+++ b/react/official/tabs/src/pages/Tab2.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { RouteComponentProps } from 'react-router';
+import { Link } from 'react-router-dom';
 import { IonContent, IonHeader, IonItem, IonLabel, IonList, IonTitle, IonToolbar } from '@ionic/react';
 
 const Tab2: React.FunctionComponent<RouteComponentProps> = ({ history }) => {
@@ -13,11 +14,13 @@ const Tab2: React.FunctionComponent<RouteComponentProps> = ({ history }) => {
       </IonHeader>
       <IonContent>
         <IonList>
-          <IonItem href="/tab2/details" onClick={(e) => {e.preventDefault(); history.push('/tab2/details'); }}>
-            <IonLabel>
-              <h2>Go to detail</h2>
-            </IonLabel>
-          </IonItem>
+          <Link to="/tab2/details">
+            <IonItem>
+              <IonLabel>
+                <h2>Go to detail</h2>
+              </IonLabel>
+            </IonItem>
+          </Link>
         </IonList>
       </IonContent>
     </>

--- a/react/official/tabs/src/pages/Tab2.tsx
+++ b/react/official/tabs/src/pages/Tab2.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { RouteComponentProps } from 'react-router';
-import { Link } from 'react-router-dom';
 import { IonContent, IonHeader, IonItem, IonLabel, IonList, IonTitle, IonToolbar } from '@ionic/react';
 
 const Tab2: React.FunctionComponent<RouteComponentProps> = ({ history }) => {
@@ -14,13 +13,11 @@ const Tab2: React.FunctionComponent<RouteComponentProps> = ({ history }) => {
       </IonHeader>
       <IonContent>
         <IonList>
-          <Link to="/tab2/details">
-            <IonItem>
-              <IonLabel>
-                <h2>Go to detail</h2>
-              </IonLabel>
-            </IonItem>
-          </Link>
+          <IonItem href="/tab2/details">
+            <IonLabel>
+              <h2>Go to detail</h2>
+            </IonLabel>
+          </IonItem>
         </IonList>
       </IonContent>
     </>


### PR DESCRIPTION
`onClick` handlers are functional but they are not accessible.  Replace them with `Link` to create accessible anchor tags.

FYI: I was not able to figure out how to use Link tags with the individual tabs. Wrapping the tabs in Links made them disappear.  Wrapping the content of the tabs in `Links` worked but affected the styling.

Fixes #823 