### PR TITLE
fix(karmaConf): code coverage on the root folder

### DIFF
--- a/angular/base/karma.conf.js
+++ b/angular/base/karma.conf.js
@@ -16,7 +16,7 @@ module.exports = function (config) {
       clearContext: false // leave Jasmine Spec Runner output visible in browser
     },
     coverageIstanbulReporter: {
-      dir: require('path').join(__dirname, '../coverage'),
+      dir: require('path').join(__dirname, './coverage'),
       reports: ['html', 'lcovonly', 'text-summary'],
       fixWebpackSourcePaths: true
     },


### PR DESCRIPTION
The code coverage report generated should be on the root of the project folder