### PR TITLE
fix(menu): delete DEPRECATED error message

### DIFF
--- a/angular/official/sidemenu/src/app/app.component.html
+++ b/angular/official/sidemenu/src/app/app.component.html
@@ -1,6 +1,6 @@
 <ion-app>
-  <ion-split-pane>
-    <ion-menu type="overlay">
+  <ion-split-pane contentId="main-content">
+    <ion-menu type="overlay" contentId="main-content">
       <ion-header>
         <ion-toolbar>
           <ion-title>Menu</ion-title>
@@ -19,6 +19,6 @@
         </ion-list>
       </ion-content>
     </ion-menu>
-    <ion-router-outlet main></ion-router-outlet>
+    <ion-router-outlet id="main-content"></ion-router-outlet>
   </ion-split-pane>
 </ion-app>


### PR DESCRIPTION
- Use the "contentId" property instead of [main] attribute

![スクリーンショット 2019-10-22 0 52 57](https://user-images.githubusercontent.com/9690024/67221379-4d2ac180-f466-11e9-8d8f-84a934249fc9.png)

Thanks.