### PR TITLE
Remove duplicate @angular/compiler dependency

### DIFF
--- a/angular/base/package.json
+++ b/angular/base/package.json
@@ -14,7 +14,6 @@
   "private": true,
   "dependencies": {
     "@angular/common": "~8.1.2",
-    "@angular/compiler": "~8.1.2",
     "@angular/core": "~8.1.2",
     "@angular/forms": "~8.1.2",
     "@angular/platform-browser": "~8.1.2",


### PR DESCRIPTION
It was in both dependencies and devDependencies of package.json and npm was giving a warning. I removed it from dependencies and kept it in devDependencies.