### PR TITLE
add reference to theme.css styling

### DIFF
--- a/react/base/src/App.tsx
+++ b/react/base/src/App.tsx
@@ -16,6 +16,7 @@ import '@ionic/react/css/flex-utils.css';
 import '@ionic/react/css/display.css';
 
 /* Theme variables */
+import './theme.css'
 import './theme/variables.css';
 
 const App: React.FunctionComponent = () => {


### PR DESCRIPTION
When creating my first starter app using the react starter, i noticed that the theme.css was nowhere to be used in the app.
For newcomers who want to adjust some of the base theme colors (for example the toolbar) it's pretty frustrating to find out that the theme.css is not yet used in the app