### PR TITLE
Specify tslint packages as dev deps of react

### DIFF
--- a/react/base/package.json
+++ b/react/base/package.json
@@ -19,6 +19,10 @@
     "react-scripts": "3.2.0",
     "typescript": "3.6.3"
   },
+  "devDependencies": {
+    "tslint": "^5.20.0",
+    "tslint-react": "^4.1.0"
+  },
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",


### PR DESCRIPTION
Do not depend on `tslint` and `tslint-react` being installed globally.