### PR TITLE
feat: react starter kits add git ignore idea files

### DIFF
--- a/react/base/.gitignore
+++ b/react/base/.gitignore
@@ -18,6 +18,7 @@
 .env.test.local
 .env.production.local
 .vscode
+.idea
 
 npm-debug.log*
 yarn-debug.log*


### PR DESCRIPTION
Add `.idea` to the `.gitignore` of the react starter kits in order to ignore Jetbrains IDE configurations files.