### PR TITLE
Use routerLinkActive to highlight current menu item

### DIFF
--- a/angular/official/sidemenu/src/app/app.component.html
+++ b/angular/official/sidemenu/src/app/app.component.html
@@ -7,7 +7,7 @@
           <ion-note>hi@ionicframework.com</ion-note>
 
           <ion-menu-toggle auto-hide="false" *ngFor="let p of appPages; let i = index">
-            <ion-item (click)="selectedIndex = i" routerDirection="root" [routerLink]="[p.url]" lines="none" detail="false" [class.selected]="selectedIndex == i">
+            <ion-item (click)="selectedIndex = i" routerDirection="root" [routerLink]="[p.url]" routerLinkActive="selected" lines="none" detail="false">
               <ion-icon slot="start" [ios]="p.icon + '-outline'" [md]="p.icon + '-sharp'"></ion-icon>
               <ion-label>{{ p.title }}</ion-label>
             </ion-item>


### PR DESCRIPTION
Using a 'selectedIndex' was not enough as the click event isn't triggered upon a browser's back button click.
[routerLinkActive](https://angular.io/api/router/RouterLinkActive) does the job as expected.

Solve issue #1166 