### PR TITLE
fixes #1171

### DIFF
--- a/react/official/sidemenu/src/App.tsx
+++ b/react/official/sidemenu/src/App.tsx
@@ -26,19 +26,16 @@ import './theme/variables.css';
 
 const App: React.FC = () => {
 
-  const [selectedPage, setSelectedPage] = useState('');
-
   return (
     <IonApp>
       <IonReactRouter>
         <IonSplitPane contentId="main">
-          <Menu selectedPage={selectedPage} />
+          <Menu />
           <IonRouterOutlet id="main">
             <Route path="/page/:name" render={(props) => {
-              setSelectedPage(props.match.params.name);
               return <Page {...props} />;
             }} exact={true} />
-            <Route path="/" render={() => <Redirect to="/page/Inbox" />} exact={true} />
+          	<Redirect exact from="/" to="/page/Inbox" />
           </IonRouterOutlet>
         </IonSplitPane>
       </IonReactRouter>

--- a/react/official/sidemenu/src/App.tsx
+++ b/react/official/sidemenu/src/App.tsx
@@ -1,6 +1,6 @@
 import Menu from './components/Menu';
 import Page from './pages/Page';
-import React, { useState } from 'react';
+import React from 'react';
 import { IonApp, IonRouterOutlet, IonSplitPane } from '@ionic/react';
 import { IonReactRouter } from '@ionic/react-router';
 import { Redirect, Route } from 'react-router-dom';

--- a/react/official/sidemenu/src/components/Menu.tsx
+++ b/react/official/sidemenu/src/components/Menu.tsx
@@ -9,14 +9,10 @@ import {
   IonMenuToggle,
   IonNote,
 } from '@ionic/react';
-import React from 'react';
-import { RouteComponentProps, withRouter } from 'react-router-dom';
+import React from "react";
+import { withRouter, useLocation } from "react-router-dom";
 import { archiveOutline, archiveSharp, bookmarkOutline, heartOutline, heartSharp, mailOutline, mailSharp, paperPlaneOutline, paperPlaneSharp, trashOutline, trashSharp, warningOutline, warningSharp } from 'ionicons/icons';
 import './Menu.css';
-
-interface MenuProps extends RouteComponentProps {
-  selectedPage: string;
-}
 
 interface AppPage {
   url: string;
@@ -66,7 +62,8 @@ const appPages: AppPage[] = [
 
 const labels = ['Family', 'Friends', 'Notes', 'Work', 'Travel', 'Reminders'];
 
-const Menu: React.FunctionComponent<MenuProps> = ({ selectedPage }) => {
+const Menu: React.FunctionComponent = () => {
+	let location = useLocation();
 
   return (
     <IonMenu contentId="main" type="overlay">
@@ -77,7 +74,7 @@ const Menu: React.FunctionComponent<MenuProps> = ({ selectedPage }) => {
           {appPages.map((appPage, index) => {
             return (
               <IonMenuToggle key={index} autoHide={false}>
-                <IonItem className={selectedPage === appPage.title ? 'selected' : ''} routerLink={appPage.url} routerDirection="none" lines="none" detail={false}>
+                <IonItem className={location.pathname === appPage.url ? "selected" : ""}  routerLink={appPage.url} routerDirection="none" lines="none" detail={false}>
                   <IonIcon slot="start" icon={appPage.iosIcon} />
                   <IonLabel>{appPage.title}</IonLabel>
                 </IonItem>


### PR DESCRIPTION
In addition to the error you run into all sorts of issues when adding a page not using the `Page` component. I think it's something with calling `setSelectedPage` in the `render` of the `Route` component, causing the component to reload and `render` to be called again often for the previous page instead of the new page.


fixes #1171