### PR TITLE
fix(angular): add tslint rule sort-keys false

### DIFF
--- a/angular/base/tslint.json
+++ b/angular/base/tslint.json
@@ -140,7 +140,8 @@
     "template-banana-in-box": true,
     "template-no-negated-async": true,
     "use-lifecycle-interface": true,
-    "use-pipe-transform-interface": true
+    "use-pipe-transform-interface": true,
+    "object-literal-sort-keys": false
   },
   "rulesDirectory": [
     "codelyzer"


### PR DESCRIPTION
Now, sample of Ionic Documentation is warned from tslint. 

For examle:

```ts
    const alert = await this.alertController.create({
      header: 'Confirm!',
      message: 'Message <strong>text</strong>!!!',
      buttons: [
        {
          text: 'Cancel',
          role: 'cancel',
          cssClass: 'secondary',
          handler: (blah) => {
            console.log('Confirm Cancel: blah');
          }
        }, {
          text: 'Okay',
          handler: () => {
            console.log('Confirm Okay');
          }
        }
      ]
    });
```

tslint require `object-literal-sort-keys` :

```ts
    const alert = await this. alertController.create({
      buttons: [
        {
          cssClass: 'secondary',
          handler: (blah) => {
            console.log('Confirm Cancel: blah');
          },
          role: 'cancel',
          text: 'Cancel',
        }, {
          handler: () => {
            console.log('Confirm Okay');
          },
          text: 'Okay',
        },
      ],
      header: 'Confirm!',
      message: 'Message <strong>text</strong>!!!',
    });
```

But I feel this code is difficult to read, and difficult to explain. So I added a rule.