### PR TITLE
Allow lazy-loaded files and exclude tests

### DIFF
--- a/angular/base/tsconfig.app.json
+++ b/angular/base/tsconfig.app.json
@@ -9,6 +9,10 @@
     "src/polyfills.ts"
   ],
   "include": [
+    "src/**/*.ts",
     "src/**/*.d.ts"
+  ],
+  "exclude": [
+    "src/**/*.spec.ts"
   ]
 }


### PR DESCRIPTION
It appears I was a little too aggressive with https://github.com/ionic-team/starters/pull/1274. This PR fixes things so tests aren't included and files that are lazy-loaded are compiled.