### PR TITLE
fix(react): sidemenu imported ios and md icons but only used ios on both

### DIFF
--- a/react/official/sidemenu/src/components/Menu.tsx
+++ b/react/official/sidemenu/src/components/Menu.tsx
@@ -76,7 +76,7 @@ const Menu: React.FC = () => {
             return (
               <IonMenuToggle key={index} autoHide={false}>
                 <IonItem className={location.pathname === appPage.url ? 'selected' : ''} routerLink={appPage.url} routerDirection="none" lines="none" detail={false}>
-                  <IonIcon slot="start" icon={appPage.iosIcon} />
+                  <IonIcon slot="start" ios={appPage.iosIcon} md={appPage.mdIcon} />
                   <IonLabel>{appPage.title}</IonLabel>
                 </IonItem>
               </IonMenuToggle>


### PR DESCRIPTION
I noticed the react starter for sidemenu made a point to import icons for both iOS and MD but only the iOS icons were used on the menu for both platforms.