### PR TITLE
chore: remove android-minSdkVersion

### DIFF
--- a/integrations/cordova/config.xml
+++ b/integrations/cordova/config.xml
@@ -12,7 +12,6 @@
     <allow-intent href="mailto:*" />
     <allow-intent href="geo:*" />
     <preference name="ScrollEnabled" value="false" />
-    <preference name="android-minSdkVersion" value="19" />
     <preference name="BackupWebStorage" value="none" />
     <preference name="SplashMaintainAspectRatio" value="true" />
     <preference name="FadeSplashScreenDuration" value="300" />


### PR DESCRIPTION
in cordova-android 9, the minSdkVersion will be bumped to 22, so having it set to 19 here will cause issues
in cordova-android 8, the minSdkVersion is 19, so no preference is needed 

because of that, I think it's better to not set the preference and let the cordova-android version used decide