### PR TITLE
Fix `ionic start sidemenu`

### DIFF
--- a/angular/official/sidemenu/src/app/app.component.ts
+++ b/angular/official/sidemenu/src/app/app.component.ts
@@ -13,6 +13,9 @@ export class AppComponent {
     { title: 'Trash', url: '/folder/Trash', icon: 'trash' },
     { title: 'Spam', url: '/folder/Spam', icon: 'warning' },
   ];
+  
+  public selectedIndex: number;
+  
   public labels = ['Family', 'Friends', 'Notes', 'Work', 'Travel', 'Reminders'];
   constructor() {}
 }


### PR DESCRIPTION
The ionic sidemenu starter project fails during a production build because selectIndex is used in the UI but isn't defined on the component class.