### PR TITLE
Add icon support for iOS PWA

### DIFF
--- a/react/base/public/index.html
+++ b/react/base/public/index.html
@@ -22,6 +22,8 @@
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-title" content="Ionic App" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black" />
+    <link rel="apple-touch-icon" href="%PUBLIC_URL%/assets/icon/icon.png">
+    
   </head>
 
   <body>


### PR DESCRIPTION
"apple-touch-icon" is required for iOS PWA to use icon.png for App icons on homescreen.
Didn't test for Angular but it should need this too.