### PR TITLE
fix(angular): Update jasmine-core to 3.7.1

### DIFF
--- a/angular/base/package.json
+++ b/angular/base/package.json
@@ -44,7 +44,7 @@
     "eslint-plugin-import": "2.22.1",
     "eslint-plugin-jsdoc": "30.7.6",
     "eslint-plugin-prefer-arrow": "1.2.2",
-    "jasmine-core": "~3.6.0",
+    "jasmine-core": "~3.7.1",
     "jasmine-spec-reporter": "~5.0.0",
     "karma": "~5.2.0",
     "karma-chrome-launcher": "~3.1.0",


### PR DESCRIPTION
karma-jasmine-html-reporter 1.6.0 was released as it requires jasmine-core >=3.7.1, so npm install is failing on newly created angular apps

another option is to change `"karma-jasmine-html-reporter": "^1.5.0"` to `"karma-jasmine-html-reporter": "~1.5.0",`