### PR TITLE
fix(angular): use @angular-devkit/build-angular 0.1102.10 to resolve peer dependency issues

### DIFF
--- a/angular/base/package.json
+++ b/angular/base/package.json
@@ -25,7 +25,7 @@
     "zone.js": "~0.10.2"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "~0.1102.4",
+    "@angular-devkit/build-angular": "0.1102.10",
     "@angular-eslint/builder": "2.0.2",
     "@angular-eslint/eslint-plugin": "2.0.2",
     "@angular-eslint/eslint-plugin-template": "2.0.2",


### PR DESCRIPTION
newer versions fail to install on npm 7 