### PR TITLE
fix(angular): Update jasmine-core for npm 7

### DIFF
--- a/angular/base/package.json
+++ b/angular/base/package.json
@@ -44,7 +44,7 @@
     "eslint-plugin-import": "2.22.1",
     "eslint-plugin-jsdoc": "30.7.6",
     "eslint-plugin-prefer-arrow": "1.2.2",
-    "jasmine-core": "~3.7.1",
+    "jasmine-core": "~3.8.0",
     "jasmine-spec-reporter": "~5.0.0",
     "karma": "~6.3.2",
     "karma-chrome-launcher": "~3.1.0",


### PR DESCRIPTION
latest `karma-jasmine-html-reporter` requires `jasmine-core` >= 3.8 (latest at the moment), so the starter template fails to install on npm 7