### PR TITLE
fix(vue): bump typescript version for vue 3.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,7 +97,7 @@ jobs:
       - run: npm run src:build
       - run: rm -rf node_modules/@types
       - run: npm run starters:find-redundant
-      - run: npm run starters:build
+      - run: npm run starters:build -- --current
       - run: npm run starters:generate-checksum
       - persist_to_workspace:
           root: /tmp/workspace

--- a/vue/base/package.json
+++ b/vue/base/package.json
@@ -13,7 +13,7 @@
     "@ionic/vue": "^5.4.0",
     "@ionic/vue-router": "^5.4.0",
     "core-js": "^3.6.5",
-    "vue": "^3.0.0-0",
+    "vue": "^3.2.1",
     "vue-router": "^4.0.0-0"
   },
   "devDependencies": {

--- a/vue/base/package.json
+++ b/vue/base/package.json
@@ -32,7 +32,7 @@
     "@vue/test-utils": "^2.0.0-0",
     "eslint": "^6.7.2",
     "eslint-plugin-vue": "^7.0.0-0",
-    "typescript": "~3.9.3",
+    "typescript": "^4.3.5",
     "vue-jest": "^5.0.0-0"
   }
 }


### PR DESCRIPTION
Vue 3.2 requires Typescript 4.1+, otherwise you will get compilation errors.

I also added `-- --current` to have the starters built against the PR rather than `main` because `main` will install Vue 3.2 with Typescript 3.x, causing the build to fail.