### PR TITLE
fix(vue): add vue loader to avoid crashing on appflow

### DIFF
--- a/vue/base/package.json
+++ b/vue/base/package.json
@@ -33,6 +33,7 @@
     "eslint": "^6.7.2",
     "eslint-plugin-vue": "^7.0.0-0",
     "typescript": "^4.3.5",
-    "vue-jest": "^5.0.0-0"
+    "vue-jest": "^5.0.0-0",
+    "vue-loader-v16": "npm:vue-loader@^16.1.0"
   }
 }


### PR DESCRIPTION
Vue CLI Server v4 has an optional dependency on `vue-loader-v16`. This was moved to optional dependencies to fix an issue with npm 5.6: https://github.com/vuejs/vue-cli/issues/5715

Unfortunately, this package is actually required to build a Vue app. Installing `npm install --no-optional` and then `npm run build` will cause the build to fail due to the missing `vue-loader-v16` package.

Appflow currently uses this `--no-optional` flag and Vue starters are failing to build as a result. I am making this change for now, and it will be removed when Ionic 6 ships. In Ionic 6 we are using Vue CLI v5 which does not depend on `vue-loader-v16` at all.