### PR TITLE
fix(vue): add missing plugin dependency

### DIFF
--- a/vue/base/package.json
+++ b/vue/base/package.json
@@ -34,6 +34,7 @@
     "eslint-plugin-vue": "^7.0.0-0",
     "typescript": "^4.3.5",
     "vue-jest": "^5.0.0-0",
-    "vue-loader-v16": "npm:vue-loader@^16.1.0"
+    "vue-loader-v16": "npm:vue-loader@^16.1.0",
+    "fork-ts-checker-webpack-plugin-v5": "npm:fork-ts-checker-webpack-plugin@^5.0.11"
   }
 }


### PR DESCRIPTION
Similar to https://github.com/ionic-team/starters/pull/1699. Will no longer be needed with the Vue CLI v5 update.