### PR TITLE
chore(react): bump react-scripts to v5

### DIFF
--- a/react/base/package.json
+++ b/react/base/package.json
@@ -19,7 +19,7 @@
     "react-dom": "^17.0.1",
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0",
-    "react-scripts": "4.0.2",
+    "react-scripts": "^5.0.0",
     "typescript": "^4.1.3",
     "web-vitals": "^0.2.4",
     "workbox-background-sync": "^5.1.4",


### PR DESCRIPTION
Workaround for https://github.com/facebook/create-react-app/issues/11773#issuecomment-996540501. Also, react-scripts 5 is latest so we should be shipping this with Ionic apps anyways.

Related Ionic issue: https://github.com/ionic-team/ionic-framework/issues/24479