### PR TITLE
fix(angular): add .angular to gitignore

### DIFF
--- a/angular/base/.gitignore
+++ b/angular/base/.gitignore
@@ -29,3 +29,4 @@ npm-debug.log*
 /platforms
 /plugins
 /www
+/.angular

--- a/angular/base/.gitignore
+++ b/angular/base/.gitignore
@@ -17,6 +17,7 @@ $RECYCLE.BIN/
 log.txt
 npm-debug.log*
 
+/.angular
 /.idea
 /.ionic
 /.sass-cache
@@ -29,4 +30,3 @@ npm-debug.log*
 /platforms
 /plugins
 /www
-/.angular


### PR DESCRIPTION
The .angular directory is being committed to repos in Ionic starter apps with Angular 13 when it should not be.

Closes #1710