### PR TITLE
set android scheme to http

### DIFF
--- a/integrations/cordova/config.xml
+++ b/integrations/cordova/config.xml
@@ -24,6 +24,7 @@
     <preference name="SplashScreen" value="screen" />
     <preference name="SplashScreenDelay" value="3000" />
     <platform name="android">
+        <preference name="Scheme" value="http" />
         <edit-config file="app/src/main/AndroidManifest.xml" mode="merge" target="/manifest/application" xmlns:android="http://schemas.android.com/apk/res/android">
             <application android:networkSecurityConfig="@xml/network_security_config" />
         </edit-config>


### PR DESCRIPTION
cordova-android 10 loads from `https://localhost` by default, but cordova-plugin-ionic-webview defaults to http if the scheme is not set which causes CORS problems when accessing local files converted with `convertFileSrc` function.

By setting the scheme to http, cordova will load `http://localhost`, so there won't be CORS errors with local files.