### PR TITLE
fix(angular): remove duplicate routing modules

### DIFF
--- a/angular/official/tabs/src/app/tab3/tab3.module.ts
+++ b/angular/official/tabs/src/app/tab3/tab3.module.ts
@@ -1,5 +1,4 @@
 import { IonicModule } from '@ionic/angular';
-import { RouterModule } from '@angular/router';
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
@@ -14,8 +13,7 @@ import { Tab3PageRoutingModule } from './tab3-routing.module';
     CommonModule,
     FormsModule,
     ExploreContainerComponentModule,
-    RouterModule.forChild([{ path: '', component: Tab3Page }]),
-    Tab3PageRoutingModule,
+    Tab3PageRoutingModule
   ],
   declarations: [Tab3Page]
 })


### PR DESCRIPTION
This PR remove duplicated routing in `tab3.module.ts` added by #1225