### PR TITLE
fix(angular): add missing zone-flags

### DIFF
--- a/angular/base/src/polyfills.ts
+++ b/angular/base/src/polyfills.ts
@@ -41,6 +41,7 @@
  *  (window as any).__Zone_enable_cross_context_check = true;
  *
  */
+import './zone-flags';
 
 /***************************************************************************************************
  * Zone JS is required by default for Angular itself.


### PR DESCRIPTION
This PR add back the zone flags setting removed by #1744

The `__Zone_disable_customElements = true` setting is to address [bug: angular change detection gets triggered several times during element creation](https://github.com/ionic-team/ionic-framework/issues/18020) issue.

Although the original issue is reported while using Ionic 4 + Angular 7,
I believe this is still relevant for Ionic 6 + Angular 15.