### PR TITLE
fix(angular): remove `~` for sass imports

### DIFF
--- a/angular/base/src/global.scss
+++ b/angular/base/src/global.scss
@@ -10,17 +10,17 @@
  */
 
 /* Core CSS required for Ionic components to work properly */
-@import "~@ionic/angular/css/core.css";
+@import "@ionic/angular/css/core.css";
 
 /* Basic CSS for apps built with Ionic */
-@import "~@ionic/angular/css/normalize.css";
-@import "~@ionic/angular/css/structure.css";
-@import "~@ionic/angular/css/typography.css";
-@import '~@ionic/angular/css/display.css';
+@import "@ionic/angular/css/normalize.css";
+@import "@ionic/angular/css/structure.css";
+@import "@ionic/angular/css/typography.css";
+@import '@ionic/angular/css/display.css';
 
 /* Optional CSS utils that can be commented out */
-@import "~@ionic/angular/css/padding.css";
-@import "~@ionic/angular/css/float-elements.css";
-@import "~@ionic/angular/css/text-alignment.css";
-@import "~@ionic/angular/css/text-transformation.css";
-@import "~@ionic/angular/css/flex-utils.css";
+@import "@ionic/angular/css/padding.css";
+@import "@ionic/angular/css/float-elements.css";
+@import "@ionic/angular/css/text-alignment.css";
+@import "@ionic/angular/css/text-transformation.css";
+@import "@ionic/angular/css/flex-utils.css";


### PR DESCRIPTION
Resolves #1738 

According to [this part of webpack's documentation about `sass-loader`](https://webpack.js.org/loaders/sass-loader/#resolving-import-at-rules):

> Using `~` is deprecated and can be removed from your code (**we recommend it**)

<img width="1004" alt="image" src="https://user-images.githubusercontent.com/16042676/202944111-edb1c8ee-8c77-4bb2-a1b1-689727c09baf.png">

So the `~` can be safely removed.