### PR TITLE
fix(tabs): tab icons have aria-hidden

### DIFF
--- a/angular/official/tabs/src/app/tabs/tabs.page.html
+++ b/angular/official/tabs/src/app/tabs/tabs.page.html
@@ -2,17 +2,17 @@
 
   <ion-tab-bar slot="bottom">
     <ion-tab-button tab="tab1">
-      <ion-icon name="triangle"></ion-icon>
+      <ion-icon name="triangle" aria-hidden="true"></ion-icon>
       <ion-label>Tab 1</ion-label>
     </ion-tab-button>
 
     <ion-tab-button tab="tab2">
-      <ion-icon name="ellipse"></ion-icon>
+      <ion-icon name="ellipse" aria-hidden="true"></ion-icon>
       <ion-label>Tab 2</ion-label>
     </ion-tab-button>
 
     <ion-tab-button tab="tab3">
-      <ion-icon name="square"></ion-icon>
+      <ion-icon name="square" aria-hidden="true"></ion-icon>
       <ion-label>Tab 3</ion-label>
     </ion-tab-button>
   </ion-tab-bar>

--- a/react/official/tabs/src/App.tsx
+++ b/react/official/tabs/src/App.tsx
@@ -56,15 +56,15 @@ const App: React.FC = () => (
         </IonRouterOutlet>
         <IonTabBar slot="bottom">
           <IonTabButton tab="tab1" href="/tab1">
-            <IonIcon icon={triangle} />
+            <IonIcon icon={triangle} aria-hidden="true" />
             <IonLabel>Tab 1</IonLabel>
           </IonTabButton>
           <IonTabButton tab="tab2" href="/tab2">
-            <IonIcon icon={ellipse} />
+            <IonIcon icon={ellipse} aria-hidden="true" />
             <IonLabel>Tab 2</IonLabel>
           </IonTabButton>
           <IonTabButton tab="tab3" href="/tab3">
-            <IonIcon icon={square} />
+            <IonIcon icon={square} aria-hidden="true" />
             <IonLabel>Tab 3</IonLabel>
           </IonTabButton>
         </IonTabBar>

--- a/vue/official/tabs/src/views/TabsPage.vue
+++ b/vue/official/tabs/src/views/TabsPage.vue
@@ -4,17 +4,17 @@
       <ion-router-outlet></ion-router-outlet>
       <ion-tab-bar slot="bottom">
         <ion-tab-button tab="tab1" href="/tabs/tab1">
-          <ion-icon :icon="triangle" />
+          <ion-icon :icon="triangle" aria-hidden="true" />
           <ion-label>Tab 1</ion-label>
         </ion-tab-button>
 
         <ion-tab-button tab="tab2" href="/tabs/tab2">
-          <ion-icon :icon="ellipse" />
+          <ion-icon :icon="ellipse" aria-hidden="true" />
           <ion-label>Tab 2</ion-label>
         </ion-tab-button>
 
         <ion-tab-button tab="tab3" href="/tabs/tab3">
-          <ion-icon :icon="square" />
+          <ion-icon :icon="square" aria-hidden="true" />
           <ion-label>Tab 3</ion-label>
         </ion-tab-button>
       </ion-tab-bar>


### PR DESCRIPTION
The icons in each tab serve as decoration as each tab button has a visible label. As a result, they should not be announced by screen readers. This PR adds `aria-hidden="true"` to the icons used in each tabs starter app.