### PR TITLE
Make tarballs portable

### DIFF
--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -61,6 +61,7 @@ export class DeployCommand extends Command {
           {
             gzip: true,
             cwd: dir,
+            portable: true,
             filter: (p, _stat) => {
               const filePath = path.relative(dir, path.resolve(dir, p));
 


### PR DESCRIPTION
This will omit system-specific metadata such as user ID and group ID from the tarball. This will prevent recent versions of Git from complaining about "dubious ownership in repository" if a starter template is extracted by the root user.