### PR TITLE
fix(react): browserslist uses same config for dev and prod

### DIFF
--- a/react/base/package.json
+++ b/react/base/package.json
@@ -48,19 +48,12 @@
       "react-app/jest"
     ]
   },
-  "browserslist": {
-    "production": [
-      "Chrome >=60",
-      "ChromeAndroid >=60",
-      "Firefox >=63",
-      "Edge >=79",
-      "Safari >=13",
-      "iOS >=13"
-    ],
-    "development": [
-      "last 1 chrome version",
-      "last 1 firefox version",
-      "last 1 safari version"
-    ]
-  }
+  "browserslist": [
+    "Chrome >=60",
+    "ChromeAndroid >=60",
+    "Firefox >=63",
+    "Edge >=79",
+    "Safari >=13",
+    "iOS >=13"
+  ]
 }


### PR DESCRIPTION
Running an app in development mode omits polyfills/transpiling necessary for an app to run on older versions of browsers. This PR updates the browserslist config for React to use the same config across dev and prod.