### PR TITLE
fix(angular): use standalone components

### DIFF
--- a/angular/base/angular.json
+++ b/angular/base/angular.json
@@ -5,7 +5,12 @@
   "projects": {
     "app": {
       "projectType": "application",
-      "schematics": {},
+      "schematics": {
+        "@ionic/angular-toolkit:page": {
+          "styleext": "scss",
+          "standalone": true
+        }
+      },
       "root": "",
       "sourceRoot": "src",
       "prefix": "app",

--- a/angular/base/package.json
+++ b/angular/base/package.json
@@ -36,7 +36,7 @@
     "@angular/compiler": "^15.0.0",
     "@angular/compiler-cli": "^15.0.0",
     "@angular/language-service": "^15.0.0",
-    "@ionic/angular-toolkit": "^8.0.0",
+    "@ionic/angular-toolkit": "^9.0.0",
     "@types/jasmine": "~4.0.0",
     "@types/node": "^12.11.1",
     "@typescript-eslint/eslint-plugin": "5.3.0",


### PR DESCRIPTION
Updates the Angular starter app to use standalone components by default. We had done most of the work in a previous commit, but we forgot to update the `angular.json` file change for `@ionic/angular-toolkit` support.