### PR TITLE
fix(docs): update links in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,30 @@
 [![Build Status][circle-badge]][circle-badge-url]
-[![Dependabot Status](https://api.dependabot.com/badges/status?host=github&identifier=109052620)](https://dependabot.com)
 
 # Ionic Starter Templates
 
 :book: **Start an Ionic app**: See our [Getting
-Started](https://ionicframework.com/getting-started/) guide.
+Started](https://ionicframework.com/docs) guide.
 
 :mega: **Support**: See our [Support Page][ionic-support] for general
 support questions. The issues on GitHub should be reserved for bug reports and
 feature requests.
 
 :sparkling_heart: **Modify or add starter templates**: See
-[CONTRIBUTING.md](https://github.com/ionic-team/starters/blob/master/CONTRIBUTING.md).
+[CONTRIBUTING.md](https://github.com/ionic-team/starters/blob/main/CONTRIBUTING.md).
 
 ### Starters
 
 Project Type        | Description                                           | Links
 --------------------|-------------------------------------------------------|-------
-**`angular`**       | Ionic Angular 4+ w/ Angular CLI for Tooling           | [base template](https://github.com/ionic-team/starters/tree/master/angular/base) / [starter templates](https://github.com/ionic-team/starters/tree/master/angular/official)
-**`ionic-angular`** | Ionic Angular 2/3 w/ `@ionic/app-scripts` for Tooling | [base template](https://github.com/ionic-team/starters/tree/master/ionic-angular/base) / [starter templates](https://github.com/ionic-team/starters/tree/master/ionic-angular/official)
-**`ionic1`**        | Ionic 1 w/ AngularJS                                  | [base template](https://github.com/ionic-team/starters/tree/master/ionic1/base) / [starter templates](https://github.com/ionic-team/starters/tree/master/ionic1/official)
-**`react`**         | React 16+ w/ react-scripts for Tooling                | [base template](https://github.com/ionic-team/starters/tree/master/react/base) / [starter templates](https://github.com/ionic-team/starters/tree/master/react/official)
-**`vue`**           | Vue 3+ w/ @vue/cli-service for Tooling                | [base template](https://github.com/ionic-team/starters/tree/master/vue/base) / [starter templates](https://github.com/ionic-team/starters/tree/master/vue/official)
+**`angular`**       | Ionic Angular 4+ w/ Angular CLI for Tooling           | [base template](https://github.com/ionic-team/starters/tree/main/angular/base) / [starter templates](https://github.com/ionic-team/starters/tree/main/angular/official)
+**`ionic-angular`** | Ionic Angular 2/3 w/ `@ionic/app-scripts` for Tooling | [base template](https://github.com/ionic-team/starters/tree/main/ionic-angular/base) / [starter templates](https://github.com/ionic-team/starters/tree/main/ionic-angular/official)
+**`ionic1`**        | Ionic 1 w/ AngularJS                                  | [base template](https://github.com/ionic-team/starters/tree/main/ionic1/base) / [starter templates](https://github.com/ionic-team/starters/tree/main/ionic1/official)
+**`react`**         | React 16+ w/ react-scripts for Tooling                | [base template](https://github.com/ionic-team/starters/tree/main/react/base) / [starter templates](https://github.com/ionic-team/starters/tree/main/react/official)
+**`vue`**           | Vue 3+ w/ @vue/cli-service for Tooling                | [base template](https://github.com/ionic-team/starters/tree/main/vue/base) / [starter templates](https://github.com/ionic-team/starters/tree/main/vue/official)
 
 ### Integrations
 
-* [Cordova](https://github.com/ionic-team/starters/tree/master/integrations/cordova)
+* [Cordova](https://github.com/ionic-team/starters/tree/main/integrations/cordova)
 
 [ionic-support]: https://ionicframework.com/support
 


### PR DESCRIPTION
This fixes some links in the docs, most notably the one to the getting started guide. I'm not sure if we need some sort of redirect to fix this on the other side or not, since other things may be linking to https://ionicframework.com/getting-started/.

I removed the dependabot because it was broken. If there's a better fix, let me know.