### PR TITLE
chore(ci): use node 16

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 16
 
       - name: Build
         run: |
@@ -58,7 +58,7 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 16
           cache: npm
           cache-dependency-path: |
             build/${{ matrix.framework }}-*/ionic.starter.json
@@ -83,7 +83,7 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 16
 
       - uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
         # the framework string. As a result "vue" will map
         # to both "vue" and "vue-vite" apps. Similarly,
         # "react" will map to both "react" and "react-vite" apps.
-        framework: ['vue', 'react', 'ionic-angular', 'ionic1']
+        framework: ['vue', 'react']
 
     runs-on: ubuntu-latest
     needs: build
@@ -64,6 +64,39 @@ jobs:
             build/${{ matrix.framework }}-*/ionic.starter.json
             build/${{ matrix.framework }}-*/package.json
 
+      - name: Test ${{ matrix.framework }}
+        run: |
+          npm install
+          rm -rf node_modules/@types
+          npm run starters:test -- --type=${{ matrix.framework }}
+          
+  test-legacy:
+    strategy:
+      matrix:
+        framework: ['ionic-angular', 'ionic1']
+    
+    runs-on: ubuntu-latest
+    needs: build
+    
+    steps:
+      - uses: actions/checkout@v2
+    
+      - uses: actions/download-artifact@v2
+        with:
+          name: build
+    
+      - run: tar -xf build.tar
+    
+      - uses: actions/setup-node@v2
+        with:
+          # Legacy starter apps do not support
+          # node 16+ which is why we have a separate job
+          node-version: 14
+          cache: npm
+          cache-dependency-path: |
+            build/${{ matrix.framework }}-*/ionic.starter.json
+            build/${{ matrix.framework }}-*/package.json
+    
       - name: Test ${{ matrix.framework }}
         run: |
           npm install


### PR DESCRIPTION
A Vue/Vite dependency is using https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing which is not supported in the version of node that our GitHub Actions scripts use. This PR bumps the scripts to use node 16 which supports nullish coalescing.

However, legacy starter apps such as `ionic-angular` and `ionic1` do not support node 16. As a result, this PR does two things:

1. Creates a legacy test step that runs node 14 for ionic-angular and ionic1 projects
2. Updates the non-legacy test step to run node 16 for modern projects.