### PR TITLE
chore(ci): update action versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: 16
 
@@ -29,7 +29,7 @@ jobs:
 
       - run: tar -cf build.tar build dist
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: build
           path: build.tar
@@ -48,15 +48,15 @@ jobs:
     needs: build
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: build
 
       - run: tar -xf build.tar
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: 16
           cache: npm
@@ -79,15 +79,15 @@ jobs:
     needs: build
     
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
     
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: build
     
       - run: tar -xf build.tar
     
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           # Legacy starter apps do not support
           # node 16+ which is why we have a separate job
@@ -112,19 +112,19 @@ jobs:
     if: ${{ github.ref == 'refs/heads/main' }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: 16
 
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: build
 
       - run: tar -xf build.tar
 
-      - uses: aws-actions/configure-aws-credentials@v1
+      - uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: us-west-2


### PR DESCRIPTION
This PR updates the following GitHub Action packages:

1. `actions/checkout@v3`
2. `actions/setup-node@v3`
3. `actions/upload-artifact@v3`
4. `actions/download-artifact@v3`
5. `aws-actions/configure-aws-credentials@v2`

Main motivation is to account for the `save-state` and `set-output` removal on May 31, 2023: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/