### PR TITLE
fix(react): gitignore dist output

### DIFF
--- a/react/base/.gitignore
+++ b/react/base/.gitignore
@@ -11,6 +11,9 @@
 # production
 /build
 
+# production - vite
+/dist 
+
 # misc
 .DS_Store
 .env.local


### PR DESCRIPTION
When moving to Vite for the React starters, the output directory for the compiled output changed from `/build` to `/dist`. This PR updates the `.gitignore` to include the new output directory. The old directory remains in the `.gitignore` as I am unsure if all templates the base template is used with, is on Vite. 


Resolves: #1776