### PR TITLE
fix(angular-standalone): add CommonModule to HomePage

### DIFF
--- a/angular-standalone/official/blank/src/app/home/home.page.ts
+++ b/angular-standalone/official/blank/src/app/home/home.page.ts
@@ -1,3 +1,4 @@
+import { CommonModule } from '@angular/common';
 import { Component } from '@angular/core';
 import { IonicModule } from '@ionic/angular';
 
@@ -6,7 +7,7 @@ import { IonicModule } from '@ionic/angular';
   templateUrl: 'home.page.html',
   styleUrls: ['home.page.scss'],
   standalone: true,
-  imports: [IonicModule],
+  imports: [CommonModule, IonicModule],
 })
 export class HomePage {
   constructor() {}


### PR DESCRIPTION
Import CommonModule for HomePage in blank angular-standalone starter