### PR TITLE
chore(angular): standardized approach for spec tests

### DIFF
--- a/angular-standalone/official/blank/src/app/home/home.page.spec.ts
+++ b/angular-standalone/official/blank/src/app/home/home.page.spec.ts
@@ -7,6 +7,10 @@ describe('HomePage', () => {
   let fixture: ComponentFixture<HomePage>;
 
   beforeEach(async () => {
+    await TestBed
+      .configureTestingModule()
+      .compileComponents();
+
     fixture = TestBed.createComponent(HomePage);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/angular-standalone/official/list/src/app/home/home.page.spec.ts
+++ b/angular-standalone/official/list/src/app/home/home.page.spec.ts
@@ -1,7 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
-import { IonicModule } from '@ionic/angular';
-import { MessageComponent } from '../message/message.component';
 
 import { HomePage } from './home.page';
 
@@ -11,7 +9,7 @@ describe('HomePage', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [HomePage, IonicModule, MessageComponent],
+      imports: [HomePage],
       providers: [provideRouter([])],
     }).compileComponents();
 

--- a/angular-standalone/official/sidemenu/src/app/app.component.spec.ts
+++ b/angular-standalone/official/sidemenu/src/app/app.component.spec.ts
@@ -1,27 +1,23 @@
-import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
-
-import { RouterTestingModule } from '@angular/router/testing';
-import { IonicModule } from '@ionic/angular';
 
 import { AppComponent } from './app.component';
 
 describe('AppComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [AppComponent, IonicModule],
+      imports: [AppComponent],
       providers: [provideRouter([])],
     }).compileComponents();
   });
 
-  it('should create the app', async () => {
+  it('should create the app', () => {
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.componentInstance;
     expect(app).toBeTruthy();
   });
 
-  it('should have menu labels', async () => {
+  it('should have menu labels', () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
     const app = fixture.nativeElement;
@@ -31,7 +27,7 @@ describe('AppComponent', () => {
     expect(menuItems[1].textContent).toContain('Outbox');
   });
 
-  it('should have urls', async () => {
+  it('should have urls', () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
     const app = fixture.nativeElement;

--- a/angular-standalone/official/tabs/src/app/explore-container/explore-container.component.spec.ts
+++ b/angular-standalone/official/tabs/src/app/explore-container/explore-container.component.spec.ts
@@ -1,5 +1,4 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { IonicModule } from '@ionic/angular';
 
 import { ExploreContainerComponent } from './explore-container.component';
 
@@ -8,9 +7,7 @@ describe('ExploreContainerComponent', () => {
   let fixture: ComponentFixture<ExploreContainerComponent>;
 
   beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [IonicModule]
-    }).compileComponents();
+    await TestBed.configureTestingModule().compileComponents();
 
     fixture = TestBed.createComponent(ExploreContainerComponent);
     component = fixture.componentInstance;

--- a/angular-standalone/official/tabs/src/app/tab1/tab1.page.spec.ts
+++ b/angular-standalone/official/tabs/src/app/tab1/tab1.page.spec.ts
@@ -1,6 +1,4 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { IonicModule } from '@ionic/angular';
-import { ExploreContainerComponent } from '../explore-container/explore-container.component';
 
 import { Tab1Page } from './tab1.page';
 
@@ -10,7 +8,7 @@ describe('Tab1Page', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [Tab1Page, IonicModule, ExploreContainerComponent],
+      imports: [Tab1Page],
     }).compileComponents();
 
     fixture = TestBed.createComponent(Tab1Page);

--- a/angular-standalone/official/tabs/src/app/tab2/tab2.page.spec.ts
+++ b/angular-standalone/official/tabs/src/app/tab2/tab2.page.spec.ts
@@ -1,7 +1,4 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { IonicModule } from '@ionic/angular';
-
-import { ExploreContainerComponent } from '../explore-container/explore-container.component';
 
 import { Tab2Page } from './tab2.page';
 
@@ -11,7 +8,7 @@ describe('Tab2Page', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [Tab2Page, IonicModule, ExploreContainerComponent],
+      imports: [Tab2Page],
     }).compileComponents();
 
     fixture = TestBed.createComponent(Tab2Page);

--- a/angular-standalone/official/tabs/src/app/tab3/tab3.page.spec.ts
+++ b/angular-standalone/official/tabs/src/app/tab3/tab3.page.spec.ts
@@ -1,6 +1,4 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { IonicModule } from '@ionic/angular';
-import { ExploreContainerComponent } from '../explore-container/explore-container.component';
 
 import { Tab3Page } from './tab3.page';
 
@@ -10,7 +8,7 @@ describe('Tab3Page', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [Tab3Page, IonicModule, ExploreContainerComponent],
+      imports: [Tab3Page],
     }).compileComponents();
 
     fixture = TestBed.createComponent(Tab3Page);

--- a/angular-standalone/official/tabs/src/app/tabs/tabs.page.spec.ts
+++ b/angular-standalone/official/tabs/src/app/tabs/tabs.page.spec.ts
@@ -1,6 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
-import { IonicModule } from '@ionic/angular';
 
 import { TabsPage } from './tabs.page';
 
@@ -10,7 +9,7 @@ describe('TabsPage', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [TabsPage, IonicModule],
+      imports: [TabsPage],
       providers: [provideRouter([])],
     }).compileComponents();
   });

--- a/angular/official/sidemenu/src/app/app.component.spec.ts
+++ b/angular/official/sidemenu/src/app/app.component.spec.ts
@@ -17,13 +17,13 @@ describe('AppComponent', () => {
     }).compileComponents();
   });
 
-  it('should create the app', async () => {
+  it('should create the app', () => {
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.componentInstance;
     expect(app).toBeTruthy();
   });
 
-  it('should have menu labels', async () => {
+  it('should have menu labels', () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
     const app = fixture.nativeElement;
@@ -33,7 +33,7 @@ describe('AppComponent', () => {
     expect(menuItems[1].textContent).toContain('Outbox');
   });
 
-  it('should have urls', async () => {
+  it('should have urls', () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
     const app = fixture.nativeElement;


### PR DESCRIPTION
Resolves #1767 

- Removes unused imports
- Removes unnecessary `async` modifiers
- Standardizes the spec test template for standalone examples