### PR TITLE
test(vue): test vue apps

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
         # the framework string. As a result "vue" will map
         # to both "vue" and "vue-vite" apps. Similarly,
         # "react" will map to both "react" and "react-vite" apps.
-        framework: ['vue', 'react']
+        framework: ['vue-vite-official-blank', 'vue-vite-official-list', 'vue-vite-official-tabs', 'vue-vite-official-sidemenu', 'react']
 
     runs-on: ubuntu-latest
     needs: build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
         # the framework string. As a result "vue" will map
         # to both "vue" and "vue-vite" apps. Similarly,
         # "react" will map to both "react" and "react-vite" apps.
-        framework: ['vue-vite-official-blank', 'vue-vite-official-list', 'vue-vite-official-tabs', 'vue-vite-official-sidemenu', 'vue-official-blank', 'vue-official-list', 'vue-official-tabs', 'vue-official-sidemenu', 'react']
+        framework: ['vue-vite-official-blank', 'vue-vite-official-list', 'vue-vite-official-tabs', 'vue-vite-official-sidemenu', 'vue-official-blank', 'vue-official-list', 'vue-official-tabs', 'vue-official-sidemenu']
 
     runs-on: ubuntu-latest
     needs: build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
         # the framework string. As a result "vue" will map
         # to both "vue" and "vue-vite" apps. Similarly,
         # "react" will map to both "react" and "react-vite" apps.
-        framework: ['vue-vite-official-blank', 'vue-vite-official-list', 'vue-vite-official-tabs', 'vue-vite-official-sidemenu', 'react']
+        framework: ['vue-vite-official-blank', 'vue-vite-official-list', 'vue-vite-official-tabs', 'vue-vite-official-sidemenu', 'vue-official-blank', 'vue-official-list', 'vue-official-tabs', 'vue-official-sidemenu', 'react']
 
     runs-on: ubuntu-latest
     needs: build
@@ -61,8 +61,8 @@ jobs:
           node-version: 16
           cache: npm
           cache-dependency-path: |
-            build/${{ matrix.framework }}-*/ionic.starter.json
-            build/${{ matrix.framework }}-*/package.json
+            build/${{ matrix.framework }}/ionic.starter.json
+            build/${{ matrix.framework }}/package.json
 
       - name: Test ${{ matrix.framework }}
         run: |

--- a/vue-vite/official/blank/ionic.starter.json
+++ b/vue-vite/official/blank/ionic.starter.json
@@ -7,6 +7,6 @@
     "www"
   ],
   "scripts": {
-    "test": "npm run build"
+    "test": "npm run build && npm run test:unit -- --watch=false && npm i --no-save concurrently && ./node_modules/.bin/concurrently \"npm run dev\" \"npm run test:e2e\" --kill-others --success first"
   }
 }

--- a/vue-vite/official/list/ionic.starter.json
+++ b/vue-vite/official/list/ionic.starter.json
@@ -7,6 +7,6 @@
     "www"
   ],
   "scripts": {
-    "test": "npm run build"
+    "test": "npm run build && npm run test:unit -- --watch=false && npm i --no-save concurrently && ./node_modules/.bin/concurrently \"npm run dev\" \"npm run test:e2e\" --kill-others --success first"
   }
 }

--- a/vue-vite/official/sidemenu/ionic.starter.json
+++ b/vue-vite/official/sidemenu/ionic.starter.json
@@ -7,6 +7,6 @@
     "www"
   ],
   "scripts": {
-    "test": "npm run build"
+    "test": "npm run build && npm run test:unit -- --watch=false && npm i --no-save concurrently && ./node_modules/.bin/concurrently \"npm run dev\" \"npm run test:e2e\" --kill-others --success first"
   }
 }

--- a/vue-vite/official/tabs/ionic.starter.json
+++ b/vue-vite/official/tabs/ionic.starter.json
@@ -7,6 +7,6 @@
     "www"
   ],
   "scripts": {
-    "test": "npm run build"
+    "test": "npm run build && npm run test:unit -- --watch=false && npm i --no-save concurrently && ./node_modules/.bin/concurrently \"npm run dev\" \"npm run test:e2e\" --kill-others --success first"
   }
 }

--- a/vue/official/blank/ionic.starter.json
+++ b/vue/official/blank/ionic.starter.json
@@ -7,6 +7,6 @@
     "www"
   ],
   "scripts": {
-    "test": "npm run build"
+    "test": "npm run build && npm run test:unit && npm run test:e2e"
   }
 }

--- a/vue/official/blank/ionic.starter.json
+++ b/vue/official/blank/ionic.starter.json
@@ -7,6 +7,6 @@
     "www"
   ],
   "scripts": {
-    "test": "npm run build && npm run test:unit && npm run test:e2e"
+    "test": "npm run build && npm run test:unit"
   }
 }

--- a/vue/official/list/ionic.starter.json
+++ b/vue/official/list/ionic.starter.json
@@ -7,6 +7,6 @@
     "www"
   ],
   "scripts": {
-    "test": "npm run build"
+    "test": "npm run build && npm run test:unit && npm run test:e2e"
   }
 }

--- a/vue/official/list/ionic.starter.json
+++ b/vue/official/list/ionic.starter.json
@@ -7,6 +7,6 @@
     "www"
   ],
   "scripts": {
-    "test": "npm run build && npm run test:unit && npm run test:e2e"
+    "test": "npm run build && npm run test:unit"
   }
 }

--- a/vue/official/sidemenu/ionic.starter.json
+++ b/vue/official/sidemenu/ionic.starter.json
@@ -7,6 +7,6 @@
     "www"
   ],
   "scripts": {
-    "test": "npm run build"
+    "test": "npm run build && npm run test:unit && npm run test:e2e"
   }
 }

--- a/vue/official/sidemenu/ionic.starter.json
+++ b/vue/official/sidemenu/ionic.starter.json
@@ -7,6 +7,6 @@
     "www"
   ],
   "scripts": {
-    "test": "npm run build && npm run test:unit && npm run test:e2e"
+    "test": "npm run build && npm run test:unit"
   }
 }

--- a/vue/official/tabs/ionic.starter.json
+++ b/vue/official/tabs/ionic.starter.json
@@ -7,6 +7,6 @@
     "www"
   ],
   "scripts": {
-    "test": "npm run build"
+    "test": "npm run build && npm run test:unit && npm run test:e2e"
   }
 }

--- a/vue/official/tabs/ionic.starter.json
+++ b/vue/official/tabs/ionic.starter.json
@@ -7,6 +7,6 @@
     "www"
   ],
   "scripts": {
-    "test": "npm run build && npm run test:unit && npm run test:e2e"
+    "test": "npm run build && npm run test:unit"
   }
 }


### PR DESCRIPTION
This PR updates our CI workflow to automatically test the Vue and Vue Vite starter app spec/e2e tests.

The following changes have been made in support of this:

1. The workflow matrix explicitly lists each app to test. This is not necessary, but this will significantly speed up the overall run time. Otherwise we'll have to build and test 8 tests sequentially.

Note: Cypress with Vue CLI was hanging indefinitely. I tried updating both Cypress and Node, but was unable to resolve the issue. Given that the Vue CLI apps are in maintenance mode, I opted to skip running the E2E tests (the spec tests are still run as is a compilation test)