### PR TITLE
chore: remove circleci badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![Build Status][circle-badge]][circle-badge-url]
-
 # Ionic Starter Templates
 
 :book: **Start an Ionic app**: See our [Getting


### PR DESCRIPTION
We haven't used CircleCI in years. Let's remove the failing badge.