### PR TITLE
test(angular): test angular apps

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
         # the framework string. As a result "vue" will map
         # to both "vue" and "vue-vite" apps. Similarly,
         # "react" will map to both "react" and "react-vite" apps.
-        framework: ['vue', 'react']
+        framework: ['angular-standalone-official-blank', 'angular-standalone-official-list', 'angular-standalone-official-tabs', 'angular-standalone-official-sidemenu', 'angular-official-blank', 'angular-official-list', 'angular-official-tabs', 'angular-official-sidemenu']
 
     runs-on: ubuntu-latest
     needs: build
@@ -61,8 +61,8 @@ jobs:
           node-version: 16
           cache: npm
           cache-dependency-path: |
-            build/${{ matrix.framework }}-*/ionic.starter.json
-            build/${{ matrix.framework }}-*/package.json
+            build/${{ matrix.framework }}/ionic.starter.json
+            build/${{ matrix.framework }}/package.json
 
       - name: Test ${{ matrix.framework }}
         run: |

--- a/angular-standalone/base/src/app/app.component.spec.ts
+++ b/angular-standalone/base/src/app/app.component.spec.ts
@@ -1,16 +1,14 @@
 import { TestBed } from '@angular/core/testing';
-import { provideRouter } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
 import { AppComponent } from './app.component';
 
 describe('AppComponent', () => {
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [AppComponent],
-      providers: [provideRouter([])],
-    }).compileComponents();
-  });
-
   it('should create the app', () => {
+    TestBed.overrideComponent(AppComponent, {
+      add: {
+        imports: [RouterTestingModule]
+      }
+    });
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.componentInstance;
     expect(app).toBeTruthy();

--- a/angular-standalone/official/blank/ionic.starter.json
+++ b/angular-standalone/official/blank/ionic.starter.json
@@ -7,6 +7,6 @@
     "www"
   ],
   "scripts": {
-    "test": "test": "npm run lint && npm run build && npm run test -- --configuration=ci --browsers=ChromeHeadless"
+    "test": "npm run lint && npm run build && npm run test -- --configuration=ci --browsers=ChromeHeadless"
   }
 }

--- a/angular-standalone/official/blank/ionic.starter.json
+++ b/angular-standalone/official/blank/ionic.starter.json
@@ -7,6 +7,6 @@
     "www"
   ],
   "scripts": {
-    "test": "npm run lint && npm run ng -- build --configuration=ci && npm run ng -- build --configuration=production --progress=false && npm run ng -- test --configuration=ci && npm run ng -- e2e --configuration=ci && npm run ng -- g pg my-page --dry-run && npm run ng -- g c my-component --dry-run"
+    "test": "test": "npm run lint && npm run build && npm run test -- --configuration=ci --browsers=ChromeHeadless"
   }
 }

--- a/angular-standalone/official/blank/src/app/home/home.page.spec.ts
+++ b/angular-standalone/official/blank/src/app/home/home.page.spec.ts
@@ -7,10 +7,6 @@ describe('HomePage', () => {
   let fixture: ComponentFixture<HomePage>;
 
   beforeEach(async () => {
-    await TestBed
-      .configureTestingModule()
-      .compileComponents();
-
     fixture = TestBed.createComponent(HomePage);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/angular-standalone/official/list/ionic.starter.json
+++ b/angular-standalone/official/list/ionic.starter.json
@@ -7,6 +7,6 @@
     "www"
   ],
   "scripts": {
-    "test": "test": "npm run lint && npm run build && npm run test -- --configuration=ci --browsers=ChromeHeadless"
+    "test": "npm run lint && npm run build && npm run test -- --configuration=ci --browsers=ChromeHeadless"
   }
 }

--- a/angular-standalone/official/list/ionic.starter.json
+++ b/angular-standalone/official/list/ionic.starter.json
@@ -7,6 +7,6 @@
     "www"
   ],
   "scripts": {
-    "test": "npm run lint && npm run ng -- build --configuration=ci && npm run ng -- build --configuration=production --progress=false && npm run ng -- test --configuration=ci && npm run ng -- e2e --configuration=ci && npm run ng -- g pg my-page --dry-run && npm run ng -- g c my-component --dry-run"
+    "test": "test": "npm run lint && npm run build && npm run test -- --configuration=ci --browsers=ChromeHeadless"
   }
 }

--- a/angular-standalone/official/list/src/app/app.component.spec.ts
+++ b/angular-standalone/official/list/src/app/app.component.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed } from '@angular/core/testing';
-import { provideRouter } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
 import { IonicModule } from '@ionic/angular';
 
 import { AppComponent } from './app.component';
@@ -7,10 +7,11 @@ import { AppComponent } from './app.component';
 describe('AppComponent', () => {
 
   beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [AppComponent, IonicModule],
-      providers: [provideRouter([])]
-    }).compileComponents();
+    TestBed.overrideComponent(AppComponent, {
+      add: {
+        imports: [RouterTestingModule]
+      }
+    });
   });
 
   it('should create the app', () => {

--- a/angular-standalone/official/sidemenu/ionic.starter.json
+++ b/angular-standalone/official/sidemenu/ionic.starter.json
@@ -7,6 +7,6 @@
     "www"
   ],
   "scripts": {
-    "test": "test": "npm run lint && npm run build && npm run test -- --configuration=ci --browsers=ChromeHeadless"
+    "test": "npm run lint && npm run build && npm run test -- --configuration=ci --browsers=ChromeHeadless"
   }
 }

--- a/angular-standalone/official/sidemenu/ionic.starter.json
+++ b/angular-standalone/official/sidemenu/ionic.starter.json
@@ -7,6 +7,6 @@
     "www"
   ],
   "scripts": {
-    "test": "npm run lint && npm run ng -- build --configuration=ci && npm run ng -- build --configuration=production --progress=false && npm run ng -- test --configuration=ci && npm run ng -- e2e --configuration=ci && npm run ng -- g pg my-page --dry-run && npm run ng -- g c my-component --dry-run"
+    "test": "test": "npm run lint && npm run build && npm run test -- --configuration=ci --browsers=ChromeHeadless"
   }
 }

--- a/angular-standalone/official/sidemenu/src/app/app.component.spec.ts
+++ b/angular-standalone/official/sidemenu/src/app/app.component.spec.ts
@@ -1,14 +1,15 @@
 import { TestBed } from '@angular/core/testing';
-import { provideRouter } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
 
 import { AppComponent } from './app.component';
 
 describe('AppComponent', () => {
   beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [AppComponent],
-      providers: [provideRouter([])],
-    }).compileComponents();
+    TestBed.overrideComponent(AppComponent, {
+      add: {
+        imports: [RouterTestingModule]
+      }
+    });
   });
 
   it('should create the app', () => {

--- a/angular-standalone/official/sidemenu/src/app/folder/folder.page.spec.ts
+++ b/angular-standalone/official/sidemenu/src/app/folder/folder.page.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { provideRouter } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
 import { IonicModule } from '@ionic/angular';
 
 import { FolderPage } from './folder.page';
@@ -9,10 +9,11 @@ describe('FolderPage', () => {
   let fixture: ComponentFixture<FolderPage>;
 
   beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [FolderPage, IonicModule],
-      providers: [provideRouter([])],
-    }).compileComponents();
+    TestBed.overrideComponent(FolderPage, {
+      add: {
+        imports: [RouterTestingModule]
+      }
+    });
 
     fixture = TestBed.createComponent(FolderPage);
     component = fixture.componentInstance;

--- a/angular-standalone/official/tabs/ionic.starter.json
+++ b/angular-standalone/official/tabs/ionic.starter.json
@@ -7,6 +7,6 @@
     "www"
   ],
   "scripts": {
-    "test": "test": "npm run lint && npm run build && npm run test -- --configuration=ci --browsers=ChromeHeadless"
+    "test": "npm run lint && npm run build && npm run test -- --configuration=ci --browsers=ChromeHeadless"
   }
 }

--- a/angular-standalone/official/tabs/ionic.starter.json
+++ b/angular-standalone/official/tabs/ionic.starter.json
@@ -7,6 +7,6 @@
     "www"
   ],
   "scripts": {
-    "test": "npm run lint && npm run ng -- build --configuration=ci && npm run ng -- build --configuration=production --progress=false && npm run ng -- test --configuration=ci && npm run ng -- e2e --configuration=ci && npm run ng -- g pg my-page --dry-run && npm run ng -- g c my-component --dry-run"
+    "test": "test": "npm run lint && npm run build && npm run test -- --configuration=ci --browsers=ChromeHeadless"
   }
 }

--- a/angular-standalone/official/tabs/src/app/explore-container/explore-container.component.spec.ts
+++ b/angular-standalone/official/tabs/src/app/explore-container/explore-container.component.spec.ts
@@ -7,8 +7,6 @@ describe('ExploreContainerComponent', () => {
   let fixture: ComponentFixture<ExploreContainerComponent>;
 
   beforeEach(async () => {
-    await TestBed.configureTestingModule().compileComponents();
-
     fixture = TestBed.createComponent(ExploreContainerComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/angular-standalone/official/tabs/src/app/tab1/tab1.page.spec.ts
+++ b/angular-standalone/official/tabs/src/app/tab1/tab1.page.spec.ts
@@ -7,10 +7,6 @@ describe('Tab1Page', () => {
   let fixture: ComponentFixture<Tab1Page>;
 
   beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [Tab1Page],
-    }).compileComponents();
-
     fixture = TestBed.createComponent(Tab1Page);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/angular-standalone/official/tabs/src/app/tab2/tab2.page.spec.ts
+++ b/angular-standalone/official/tabs/src/app/tab2/tab2.page.spec.ts
@@ -7,10 +7,6 @@ describe('Tab2Page', () => {
   let fixture: ComponentFixture<Tab2Page>;
 
   beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [Tab2Page],
-    }).compileComponents();
-
     fixture = TestBed.createComponent(Tab2Page);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/angular-standalone/official/tabs/src/app/tab3/tab3.page.spec.ts
+++ b/angular-standalone/official/tabs/src/app/tab3/tab3.page.spec.ts
@@ -7,10 +7,6 @@ describe('Tab3Page', () => {
   let fixture: ComponentFixture<Tab3Page>;
 
   beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [Tab3Page],
-    }).compileComponents();
-
     fixture = TestBed.createComponent(Tab3Page);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/angular-standalone/official/tabs/src/app/tabs/tabs.page.spec.ts
+++ b/angular-standalone/official/tabs/src/app/tabs/tabs.page.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { provideRouter } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
 
 import { TabsPage } from './tabs.page';
 
@@ -8,10 +8,11 @@ describe('TabsPage', () => {
   let fixture: ComponentFixture<TabsPage>;
 
   beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [TabsPage],
-      providers: [provideRouter([])],
-    }).compileComponents();
+    TestBed.overrideComponent(TabsPage, {
+      add: {
+        imports: [RouterTestingModule]
+      }
+    });
   });
 
   beforeEach(() => {

--- a/angular/official/blank/ionic.starter.json
+++ b/angular/official/blank/ionic.starter.json
@@ -7,6 +7,6 @@
     "www"
   ],
   "scripts": {
-    "test": "npm run lint && npm run ng -- build --configuration=ci && npm run ng -- build --configuration=production --progress=false && npm run ng -- test --configuration=ci && npm run ng -- e2e --configuration=ci && npm run ng -- g pg my-page --dry-run && npm run ng -- g c my-component --dry-run"
+    "test": "npm run lint && npm run build && npm run test -- --configuration=ci --browsers=ChromeHeadless"
   }
 }

--- a/angular/official/list/ionic.starter.json
+++ b/angular/official/list/ionic.starter.json
@@ -7,6 +7,6 @@
     "www"
   ],
   "scripts": {
-    "test": "npm run lint && npm run ng -- build --configuration=ci && npm run ng -- build --configuration=production --progress=false && npm run ng -- test --configuration=ci && npm run ng -- e2e --configuration=ci && npm run ng -- g pg my-page --dry-run && npm run ng -- g c my-component --dry-run"
+    "test": "npm run lint && npm run build && npm run test -- --configuration=ci --browsers=ChromeHeadless"
   }
 }

--- a/angular/official/sidemenu/ionic.starter.json
+++ b/angular/official/sidemenu/ionic.starter.json
@@ -7,6 +7,6 @@
     "www"
   ],
   "scripts": {
-    "test": "npm run lint && npm run ng -- build --configuration=ci && npm run ng -- build --configuration=production --progress=false && npm run ng -- test --configuration=ci && npm run ng -- e2e --configuration=ci && npm run ng -- g pg my-page --dry-run && npm run ng -- g c my-component --dry-run"
+    "test": "npm run lint && npm run build && npm run test -- --configuration=ci --browsers=ChromeHeadless"
   }
 }

--- a/angular/official/tabs/ionic.starter.json
+++ b/angular/official/tabs/ionic.starter.json
@@ -7,6 +7,6 @@
     "www"
   ],
   "scripts": {
-    "test": "npm run lint && npm run ng -- build --configuration=ci && npm run ng -- build --configuration=production --progress=false && npm run ng -- test --configuration=ci && npm run ng -- e2e --configuration=ci && npm run ng -- g pg my-page --dry-run && npm run ng -- g c my-component --dry-run"
+    "test": "npm run lint && npm run build && npm run test -- --configuration=ci --browsers=ChromeHeadless"
   }
 }


### PR DESCRIPTION
This PR updates our CI workflow to automatically test the Angular and Angular Standalone starter app spec/e2e tests.

The following changes have been made in support of this:

1. The workflow matrix explicitly lists each app to test. This is not necessary, but this will significantly speed up the overall run time. Otherwise we'll have to build and test 8 tests sequentially.