### PR TITLE
fix(angular): tab buttons have href

### DIFF
--- a/angular-standalone/official/tabs/src/app/tabs/tabs.page.html
+++ b/angular-standalone/official/tabs/src/app/tabs/tabs.page.html
@@ -1,16 +1,16 @@
 <ion-tabs>
   <ion-tab-bar slot="bottom">
-    <ion-tab-button tab="tab1">
+    <ion-tab-button tab="tab1" href="/tabs/tab1">
       <ion-icon aria-hidden="true" name="triangle"></ion-icon>
       <ion-label>Tab 1</ion-label>
     </ion-tab-button>
 
-    <ion-tab-button tab="tab2">
+    <ion-tab-button tab="tab2" href="/tabs/tab2">
       <ion-icon aria-hidden="true" name="ellipse"></ion-icon>
       <ion-label>Tab 2</ion-label>
     </ion-tab-button>
 
-    <ion-tab-button tab="tab3">
+    <ion-tab-button tab="tab3" href="/tabs/tab3">
       <ion-icon aria-hidden="true" name="square"></ion-icon>
       <ion-label>Tab 3</ion-label>
     </ion-tab-button>

--- a/angular/official/tabs/src/app/tabs/tabs.page.html
+++ b/angular/official/tabs/src/app/tabs/tabs.page.html
@@ -1,17 +1,17 @@
 <ion-tabs>
 
   <ion-tab-bar slot="bottom">
-    <ion-tab-button tab="tab1">
+    <ion-tab-button tab="tab1" href="/tabs/tab1">
       <ion-icon aria-hidden="true" name="triangle"></ion-icon>
       <ion-label>Tab 1</ion-label>
     </ion-tab-button>
 
-    <ion-tab-button tab="tab2">
+    <ion-tab-button tab="tab2" href="/tabs/tab2">
       <ion-icon aria-hidden="true" name="ellipse"></ion-icon>
       <ion-label>Tab 2</ion-label>
     </ion-tab-button>
 
-    <ion-tab-button tab="tab3">
+    <ion-tab-button tab="tab3" href="/tabs/tab3">
       <ion-icon aria-hidden="true" name="square"></ion-icon>
       <ion-label>Tab 3</ion-label>
     </ion-tab-button>


### PR DESCRIPTION
resolves #1796

The tab buttons in the Angular tabs app were missing `href` which prevented the tab buttons from being keyboard accessible.