### PR TITLE
fix(angular-standalone): remove duplicate compiler dependency

### DIFF
--- a/angular-standalone/base/package.json
+++ b/angular-standalone/base/package.json
@@ -35,7 +35,6 @@
     "@angular-eslint/template-parser": "^16.0.0",
     "@angular-eslint/schematics": "^16.0.0",
     "@angular/cli": "^16.0.0",
-    "@angular/compiler": "^16.0.0",
     "@angular/compiler-cli": "^16.0.0",
     "@angular/language-service": "^16.0.0",
     "@ionic/angular-toolkit": "^9.0.0",


### PR DESCRIPTION
The `package.json` has a duplicate `@angular/compiler` dependency. This should be a dependency of the project, not a dev dependency (Running `ng new` has the compiler as a dependency).