### PR TITLE
chore: enable dynamic font for starter templates

### DIFF
--- a/angular-standalone/base/src/theme/variables.scss
+++ b/angular-standalone/base/src/theme/variables.scss
@@ -234,3 +234,11 @@
     --ion-card-background: #1e1e1e;
   }
 }
+
+html {
+  /* 
+   * For more information on dynamic font scaling, visit the documentation:
+   * https://ionicframework.com/docs/layout/dynamic-font-scaling
+   */
+  --ion-dynamic-font: var(--ion-default-dynamic-font);
+}

--- a/angular/base/src/theme/variables.scss
+++ b/angular/base/src/theme/variables.scss
@@ -234,3 +234,11 @@
     --ion-card-background: #1e1e1e;
   }
 }
+
+html {
+  /* 
+   * For more information on dynamic font scaling, visit the documentation:
+   * https://ionicframework.com/docs/layout/dynamic-font-scaling
+   */
+  --ion-dynamic-font: var(--ion-default-dynamic-font);
+}

--- a/react-vite/base/src/theme/variables.css
+++ b/react-vite/base/src/theme/variables.css
@@ -234,3 +234,9 @@ http://ionicframework.com/docs/theming/ */
     --ion-card-background: #1e1e1e;
   }
 }
+
+html {
+  /* For more information on dynamic font scaling, visit the documentation: 
+  https://ionicframework.com/docs/layout/dynamic-font-scaling */
+  --ion-dynamic-font: var(--ion-default-dynamic-font);
+}

--- a/vue-vite/base/src/theme/variables.css
+++ b/vue-vite/base/src/theme/variables.css
@@ -234,3 +234,9 @@ http://ionicframework.com/docs/theming/ */
     --ion-card-background: #1e1e1e;
   }
 }
+
+html {
+  /* For more information on dynamic font scaling, visit the documentation: 
+  https://ionicframework.com/docs/layout/dynamic-font-scaling */
+  --ion-dynamic-font: var(--ion-default-dynamic-font);
+}


### PR DESCRIPTION
Enables the default font for dynamic font scaling.

This PR uses a link to documentation that has not been merged/released in production (yet). The docs that it will resolve will be: https://ionic-docs-git-feature-75-ionic1.vercel.app/docs/layout/dynamic-font-scaling

Testing:
- Run `npm run starters:build -- --current`
- Navigate into each `build/*` directory for the effected starters
- Install dependencies
- Run the app
- Verified that the `html` node has the new variable styles

Dev-build for font-scaling:`7.3.4-dev.11695654072.17597cce`