### PR TITLE
chore(angular): uniformize quote style

### DIFF
--- a/angular-standalone/base/src/global.scss
+++ b/angular-standalone/base/src/global.scss
@@ -16,7 +16,7 @@
 @import "@ionic/angular/css/normalize.css";
 @import "@ionic/angular/css/structure.css";
 @import "@ionic/angular/css/typography.css";
-@import '@ionic/angular/css/display.css';
+@import "@ionic/angular/css/display.css";
 
 /* Optional CSS utils that can be commented out */
 @import "@ionic/angular/css/padding.css";

--- a/angular/base/src/global.scss
+++ b/angular/base/src/global.scss
@@ -16,7 +16,7 @@
 @import "@ionic/angular/css/normalize.css";
 @import "@ionic/angular/css/structure.css";
 @import "@ionic/angular/css/typography.css";
-@import '@ionic/angular/css/display.css';
+@import "@ionic/angular/css/display.css";
 
 /* Optional CSS utils that can be commented out */
 @import "@ionic/angular/css/padding.css";


### PR DESCRIPTION
`global.scss` is mixing simple and double quotes, so teams that use a code formatter tool like [Prettier](https://prettier.io/) need to make a useless commit to fix it when starting their project.

Btw thank you so much for Ionic and Capacitor, these tools make my life wonderful!