### PR TITLE
fix(react): gitignore dist for vite

### DIFF
--- a/react-vite/base/.gitignore
+++ b/react-vite/base/.gitignore
@@ -9,7 +9,7 @@
 /coverage
 
 # production
-/build
+/dist
 
 # misc
 .DS_Store

--- a/react/base/.gitignore
+++ b/react/base/.gitignore
@@ -11,9 +11,6 @@
 # production
 /build
 
-# production - vite
-/dist 
-
 # misc
 .DS_Store
 .env.local


### PR DESCRIPTION
`dist` was added to the regular react gitignore, I've removed it from there and added it to the react-vite template