### PR TITLE
chore: deploy should run when tests pass

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -129,7 +129,7 @@ jobs:
 
   deploy:
     runs-on: ubuntu-latest
-    needs: test
+    needs: [verify-test, verify-test-legacy]
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
Deployment currently happens when all the tests are run. However, I failed to update the deploy step to only run once the tests are verified to all have passed (the "verify-test" and "verify-test-legacy") steps.

The current behavior shouldn't be causing issues, since tests must pass before PRs are merged anyways, but we should still wait for the verification step before deploying.