### PR TITLE
fix(angular): prevent invalid import recommendations

### DIFF
--- a/angular-standalone/base/.vscode/settings.json
+++ b/angular-standalone/base/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "typescript.preferences.autoImportFileExcludePatterns": ["@ionic/angular/common", "@ionic/angular"]
+}

--- a/angular/base/.vscode/settings.json
+++ b/angular/base/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-  "typescript.preferences.autoImportFileExcludePatterns": ["@ionic/angular/common"]
+  "typescript.preferences.autoImportFileExcludePatterns": ["@ionic/angular/common", "@ionic/angular/standalone"]
 }

--- a/angular/base/.vscode/settings.json
+++ b/angular/base/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "typescript.preferences.autoImportFileExcludePatterns": ["@ionic/angular/common"]
+}


### PR DESCRIPTION
This PR updates the module and starter templates for Angular to ship with a default VSCode setting that prevents importing from invalid locations.

For example, the base projects using modules will ignore import recommendations from `@ionic/angular/standalone` and `@ionic/angular/common`. Standalone projects will ignore import recommendations from `@ionic/angular` and `@ionic/angular/common`. 

