### PR TITLE
chore(ci): bump workflows to run on node v20

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 20
 
       - name: Build
         run: |
@@ -56,7 +56,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 20
           cache: npm
           cache-dependency-path: |
             build/${{ matrix.framework }}/ionic.starter.json
@@ -140,7 +140,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 20
 
       - uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
Bumps Github Action workflow job steps to use v20 (other than the legacy job step). 