### PR TITLE
fix(vue-vite): add missing peer dependency

### DIFF
--- a/vue-vite/base/package.json
+++ b/vue-vite/base/package.json
@@ -27,6 +27,7 @@
     "eslint": "^8.35.0",
     "eslint-plugin-vue": "^9.9.0",
     "jsdom": "^22.1.0",
+    "terser": "^5.4.0",
     "typescript": "^5.1.6",
     "vite": "^4.3.9",
     "vitest": "^0.32.2",


### PR DESCRIPTION
Similar to #1819, the vue vite base project had a missing peer dependency requirement for `terser`. This caused certain package managers such as `yarn` or `pnpm` to fail building the app.