### PR TITLE
fix(react): sidemenu starter app has correct links

### DIFF
--- a/react-vite/official/sidemenu/src/components/Menu.tsx
+++ b/react-vite/official/sidemenu/src/components/Menu.tsx
@@ -24,37 +24,37 @@ interface AppPage {
 const appPages: AppPage[] = [
   {
     title: 'Inbox',
-    url: '/page/Inbox',
+    url: '/folder/Inbox',
     iosIcon: mailOutline,
     mdIcon: mailSharp
   },
   {
     title: 'Outbox',
-    url: '/page/Outbox',
+    url: '/folder/Outbox',
     iosIcon: paperPlaneOutline,
     mdIcon: paperPlaneSharp
   },
   {
     title: 'Favorites',
-    url: '/page/Favorites',
+    url: '/folder/Favorites',
     iosIcon: heartOutline,
     mdIcon: heartSharp
   },
   {
     title: 'Archived',
-    url: '/page/Archived',
+    url: '/folder/Archived',
     iosIcon: archiveOutline,
     mdIcon: archiveSharp
   },
   {
     title: 'Trash',
-    url: '/page/Trash',
+    url: '/folder/Trash',
     iosIcon: trashOutline,
     mdIcon: trashSharp
   },
   {
     title: 'Spam',
-    url: '/page/Spam',
+    url: '/folder/Spam',
     iosIcon: warningOutline,
     mdIcon: warningSharp
   }


### PR DESCRIPTION
The router config for the `react-vite` apps uses `/folder`: https://github.com/ionic-team/starters/blob/2e6114a613b49d404b3eb51c64c559129a6b82b2/react-vite/official/sidemenu/src/App.tsx#L38C7-L38C7 However, we still refer to `/page` here. As a result, these links don't actually go anywhere.