### PR TITLE
chore: remove ts-node

### DIFF
--- a/angular-standalone/base/package.json
+++ b/angular-standalone/base/package.json
@@ -52,7 +52,6 @@
     "karma-coverage": "~2.2.0",
     "karma-jasmine": "~5.1.0",
     "karma-jasmine-html-reporter": "~2.1.0",
-    "ts-node": "^8.3.0",
     "typescript": "~5.2.2"
   }
 }

--- a/angular/base/package.json
+++ b/angular/base/package.json
@@ -52,7 +52,6 @@
     "karma-coverage": "~2.2.0",
     "karma-jasmine": "~5.1.0",
     "karma-jasmine-html-reporter": "~2.1.0",
-    "ts-node": "^8.3.0",
     "typescript": "~5.2.2"
   }
 }


### PR DESCRIPTION
resolves #1742

`ts-node` is outdated, but it isn't actually used anywhere in the starter apps. This PR removes the dependency.