### PR TITLE
fix(angular): variables gets loaded after global

### DIFF
--- a/angular-standalone/base/angular.json
+++ b/angular-standalone/base/angular.json
@@ -31,7 +31,7 @@
                 "output": "assets"
               }
             ],
-            "styles": ["src/theme/variables.scss", "src/global.scss"],
+            "styles": ["src/global.scss", "src/theme/variables.scss"],
             "scripts": []
           },
           "configurations": {
@@ -106,7 +106,7 @@
                 "output": "assets"
               }
             ],
-            "styles": ["src/theme/variables.scss", "src/global.scss"],
+            "styles": ["src/global.scss", "src/theme/variables.scss"],
             "scripts": []
           },
           "configurations": {

--- a/angular/base/angular.json
+++ b/angular/base/angular.json
@@ -31,7 +31,7 @@
                 "output": "./svg"
               }
             ],
-            "styles": ["src/theme/variables.scss", "src/global.scss"],
+            "styles": ["src/global.scss", "src/theme/variables.scss"],
             "scripts": []
           },
           "configurations": {
@@ -111,7 +111,7 @@
                 "output": "./svg"
               }
             ],
-            "styles": ["src/theme/variables.scss", "src/global.scss"],
+            "styles": ["src/global.scss", "src/theme/variables.scss"],
             "scripts": []
           },
           "configurations": {


### PR DESCRIPTION
One of the issues I'm seeing devs run into with the Ionic 8 beta is with trying to override the default light theme. Devs are placing their overrides in `theme/variables.scss`. However, our `angular.json` config has it so that `theme/variables.scss` is loaded before `global.scss` (where the default light theme is imported).

Since both sets of styles target the same selector, they have the same specificity and the latest style to get added to the DOM wins (`global.scss` in this case). As a result, the custom styles do not apply.

This PR switches the order so `global.scss` is loaded first. This is really only needed for Ionic 8, so I could target the `feature-8.0` branch. However, I figured it would be good to get this change out sooner since devs testing the Ionic 8 beta may create fresh apps.