### PR TITLE
refactor(apps): update paths and naming for latest v8

### DIFF
--- a/angular-standalone/base/package.json
+++ b/angular-standalone/base/package.json
@@ -21,7 +21,7 @@
     "@angular/platform-browser": "^17.0.2",
     "@angular/platform-browser-dynamic": "^17.0.2",
     "@angular/router": "^17.0.2",
-    "@ionic/angular": "7.7.2-dev.11707932366.16baf005",
+    "@ionic/angular": "^8.0.0-rc.1",
     "ionicons": "^7.2.1",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",

--- a/angular-standalone/base/package.json
+++ b/angular-standalone/base/package.json
@@ -21,7 +21,7 @@
     "@angular/platform-browser": "^17.0.2",
     "@angular/platform-browser-dynamic": "^17.0.2",
     "@angular/router": "^17.0.2",
-    "@ionic/angular": "^8.0.0-rc.1",
+    "@ionic/angular": "^8.0.0",
     "ionicons": "^7.2.1",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",

--- a/angular-standalone/base/src/global.scss
+++ b/angular-standalone/base/src/global.scss
@@ -26,12 +26,12 @@
 @import "@ionic/angular/css/flex-utils.css";
 
 /**
- * Ionic Dark Theme
+ * Ionic Dark Mode
  * -----------------------------------------------------
  * For more info, please see:
  * https://ionicframework.com/docs/theming/dark-mode
  */
 
-/* @import "@ionic/angular/css/themes/dark.always.css"; */
-/* @import "@ionic/angular/css/themes/dark.class.css"; */
-@import '@ionic/angular/css/themes/dark.system.css';
+/* @import "@ionic/angular/css/palettes/dark.always.css"; */
+/* @import "@ionic/angular/css/palettes/dark.class.css"; */
+@import '@ionic/angular/css/palettes/dark.system.css';

--- a/angular/base/package.json
+++ b/angular/base/package.json
@@ -21,7 +21,7 @@
     "@angular/platform-browser": "^17.0.2",
     "@angular/platform-browser-dynamic": "^17.0.2",
     "@angular/router": "^17.0.2",
-    "@ionic/angular": "7.7.2-dev.11707932366.16baf005",
+    "@ionic/angular": "^8.0.0-rc.1",
     "ionicons": "^7.0.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",

--- a/angular/base/package.json
+++ b/angular/base/package.json
@@ -21,7 +21,7 @@
     "@angular/platform-browser": "^17.0.2",
     "@angular/platform-browser-dynamic": "^17.0.2",
     "@angular/router": "^17.0.2",
-    "@ionic/angular": "^8.0.0-rc.1",
+    "@ionic/angular": "^8.0.0",
     "ionicons": "^7.0.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",

--- a/angular/base/src/global.scss
+++ b/angular/base/src/global.scss
@@ -26,12 +26,12 @@
 @import "@ionic/angular/css/flex-utils.css";
 
 /**
- * Ionic Dark Theme
+ * Ionic Dark Mode
  * -----------------------------------------------------
  * For more info, please see:
  * https://ionicframework.com/docs/theming/dark-mode
  */
 
-/* @import "@ionic/angular/css/themes/dark.always.css"; */
-/* @import "@ionic/angular/css/themes/dark.class.css"; */
-@import "@ionic/angular/css/themes/dark.system.css";
+/* @import "@ionic/angular/css/palettes/dark.always.css"; */
+/* @import "@ionic/angular/css/palettes/dark.class.css"; */
+@import "@ionic/angular/css/palettes/dark.system.css";

--- a/react-vite/base/package.json
+++ b/react-vite/base/package.json
@@ -12,8 +12,8 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "@ionic/react": "7.7.2-dev.11707932366.16baf005",
-    "@ionic/react-router": "7.7.2-dev.11707932366.16baf005",
+    "@ionic/react": "^8.0.0-rc.1",
+    "@ionic/react-router": "^8.0.0-rc.1",
     "@types/react-router": "^5.1.20",
     "@types/react-router-dom": "^5.3.3",
     "ionicons": "^7.0.0",

--- a/react-vite/base/package.json
+++ b/react-vite/base/package.json
@@ -12,8 +12,8 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "@ionic/react": "^8.0.0-rc.1",
-    "@ionic/react-router": "^8.0.0-rc.1",
+    "@ionic/react": "^8.0.0",
+    "@ionic/react-router": "^8.0.0",
     "@types/react-router": "^5.1.20",
     "@types/react-router-dom": "^5.3.3",
     "ionicons": "^7.0.0",

--- a/react-vite/base/src/App.tsx
+++ b/react-vite/base/src/App.tsx
@@ -15,15 +15,15 @@ import '@ionic/react/css/flex-utils.css';
 import '@ionic/react/css/display.css';
 
 /**
- * Ionic Dark Theme
+ * Ionic Dark Mode
  * -----------------------------------------------------
  * For more info, please see:
  * https://ionicframework.com/docs/theming/dark-mode
  */
 
-/* import '@ionic/react/css/themes/dark.always.css'; */
-/* import '@ionic/react/css/themes/dark.class.css'; */
-import '@ionic/react/css/themes/dark.system.css';
+/* import '@ionic/react/css/palettes/dark.always.css'; */
+/* import '@ionic/react/css/palettes/dark.class.css'; */
+import '@ionic/react/css/palettes/dark.system.css';
 
 /* Theme variables */
 import './theme/variables.css';

--- a/react-vite/official/blank/src/App.tsx
+++ b/react-vite/official/blank/src/App.tsx
@@ -20,15 +20,15 @@ import '@ionic/react/css/flex-utils.css';
 import '@ionic/react/css/display.css';
 
 /**
- * Ionic Dark Theme
+ * Ionic Dark Mode
  * -----------------------------------------------------
  * For more info, please see:
  * https://ionicframework.com/docs/theming/dark-mode
  */
 
-/* import '@ionic/react/css/themes/dark.always.css'; */
-/* import '@ionic/react/css/themes/dark.class.css'; */
-import '@ionic/react/css/themes/dark.system.css';
+/* import '@ionic/react/css/palettes/dark.always.css'; */
+/* import '@ionic/react/css/palettes/dark.class.css'; */
+import '@ionic/react/css/palettes/dark.system.css';
 
 /* Theme variables */
 import './theme/variables.css';

--- a/react-vite/official/list/src/App.tsx
+++ b/react-vite/official/list/src/App.tsx
@@ -21,15 +21,15 @@ import '@ionic/react/css/flex-utils.css';
 import '@ionic/react/css/display.css';
 
 /**
- * Ionic Dark Theme
+ * Ionic Dark Mode
  * -----------------------------------------------------
  * For more info, please see:
  * https://ionicframework.com/docs/theming/dark-mode
  */
 
-/* import '@ionic/react/css/themes/dark.always.css'; */
-/* import '@ionic/react/css/themes/dark.class.css'; */
-import '@ionic/react/css/themes/dark.system.css';
+/* import '@ionic/react/css/palettes/dark.always.css'; */
+/* import '@ionic/react/css/palettes/dark.class.css'; */
+import '@ionic/react/css/palettes/dark.system.css';
 
 /* Theme variables */
 import './theme/variables.css';

--- a/react-vite/official/sidemenu/src/App.tsx
+++ b/react-vite/official/sidemenu/src/App.tsx
@@ -21,15 +21,15 @@ import '@ionic/react/css/flex-utils.css';
 import '@ionic/react/css/display.css';
 
 /**
- * Ionic Dark Theme
+ * Ionic Dark Mode
  * -----------------------------------------------------
  * For more info, please see:
  * https://ionicframework.com/docs/theming/dark-mode
  */
 
-/* import '@ionic/react/css/themes/dark.always.css'; */
-/* import '@ionic/react/css/themes/dark.class.css'; */
-import '@ionic/react/css/themes/dark.system.css';
+/* import '@ionic/react/css/palettes/dark.always.css'; */
+/* import '@ionic/react/css/palettes/dark.class.css'; */
+import '@ionic/react/css/palettes/dark.system.css';
 
 /* Theme variables */
 import './theme/variables.css';

--- a/react-vite/official/tabs/src/App.tsx
+++ b/react-vite/official/tabs/src/App.tsx
@@ -32,15 +32,15 @@ import '@ionic/react/css/flex-utils.css';
 import '@ionic/react/css/display.css';
 
 /**
- * Ionic Dark Theme
+ * Ionic Dark Mode
  * -----------------------------------------------------
  * For more info, please see:
  * https://ionicframework.com/docs/theming/dark-mode
  */
 
-/* import '@ionic/react/css/themes/dark.always.css'; */
-/* import '@ionic/react/css/themes/dark.class.css'; */
-import '@ionic/react/css/themes/dark.system.css';
+/* import '@ionic/react/css/palettes/dark.always.css'; */
+/* import '@ionic/react/css/palettes/dark.class.css'; */
+import '@ionic/react/css/palettes/dark.system.css';
 
 /* Theme variables */
 import './theme/variables.css';

--- a/vue-vite/base/package.json
+++ b/vue-vite/base/package.json
@@ -12,8 +12,8 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "@ionic/vue": "7.7.2-dev.11707932366.16baf005",
-    "@ionic/vue-router": "7.7.2-dev.11707932366.16baf005",
+    "@ionic/vue": "^8.0.0-rc.1",
+    "@ionic/vue-router": "^8.0.0-rc.1",
     "ionicons": "^7.0.0",
     "vue": "^3.3.0",
     "vue-router": "^4.2.0"

--- a/vue-vite/base/package.json
+++ b/vue-vite/base/package.json
@@ -12,8 +12,8 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "@ionic/vue": "^8.0.0-rc.1",
-    "@ionic/vue-router": "^8.0.0-rc.1",
+    "@ionic/vue": "^8.0.0",
+    "@ionic/vue-router": "^8.0.0",
     "ionicons": "^7.0.0",
     "vue": "^3.3.0",
     "vue-router": "^4.2.0"

--- a/vue-vite/base/src/main.ts
+++ b/vue-vite/base/src/main.ts
@@ -21,15 +21,15 @@ import '@ionic/vue/css/flex-utils.css';
 import '@ionic/vue/css/display.css';
 
 /**
- * Ionic Dark Theme
+ * Ionic Dark Mode
  * -----------------------------------------------------
  * For more info, please see:
  * https://ionicframework.com/docs/theming/dark-mode
  */
 
-/* @import '@ionic/vue/css/themes/dark.always.css'; */
-/* @import '@ionic/vue/css/themes/dark.class.css'; */
-import '@ionic/vue/css/themes/dark.system.css';
+/* @import '@ionic/vue/css/palettes/dark.always.css'; */
+/* @import '@ionic/vue/css/palettes/dark.class.css'; */
+import '@ionic/vue/css/palettes/dark.system.css';
 
 /* Theme variables */
 import './theme/variables.css';
@@ -37,7 +37,7 @@ import './theme/variables.css';
 const app = createApp(App)
   .use(IonicVue)
   .use(router);
-  
+
 router.isReady().then(() => {
   app.mount('#app');
 });


### PR DESCRIPTION
- Uses the latest version of `@ionic/<framework>@next` and `@ionic/<framework>-router@next`
- Renames `css/themes` to `css/palettes` for dark mode imports