### PR TITLE
fix(angular,react): ignore .nx files

### DIFF
--- a/angular-standalone/base/.gitignore
+++ b/angular-standalone/base/.gitignore
@@ -57,6 +57,8 @@ yarn-error.log
 /.angular
 /.angular/cache
 .sass-cache/
+/.nx
+/.nx/cache
 /connect.lock
 /coverage
 /libpeerconnection.log

--- a/angular/base/.gitignore
+++ b/angular/base/.gitignore
@@ -57,6 +57,8 @@ yarn-error.log
 /.angular
 /.angular/cache
 .sass-cache/
+/.nx
+/.nx/cache
 /connect.lock
 /coverage
 /libpeerconnection.log

--- a/react-vite/base/.gitignore
+++ b/react-vite/base/.gitignore
@@ -17,6 +17,8 @@
 .env.development.local
 .env.test.local
 .env.production.local
+/.nx
+/.nx/cache
 /.vscode/*
 !/.vscode/extensions.json
 .idea

--- a/react/base/.gitignore
+++ b/react/base/.gitignore
@@ -17,6 +17,8 @@
 .env.development.local
 .env.test.local
 .env.production.local
+/.nx
+/.nx/cache
 /.vscode/*
 !/.vscode/extensions.json
 .idea


### PR DESCRIPTION
`.nx` folder has crept in because of it's use in [@angular/es-lint](https://github.com/angular-eslint/angular-eslint).