### PR TITLE
refactor(angular): migrate deprecated RouterTestingModule

### DIFF
--- a/angular-standalone/base/src/app/app.component.spec.ts
+++ b/angular-standalone/base/src/app/app.component.spec.ts
@@ -1,12 +1,12 @@
 import { TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
+import { RouterModule } from '@angular/router';
 import { AppComponent } from './app.component';
 
 describe('AppComponent', () => {
   it('should create the app', () => {
     TestBed.overrideComponent(AppComponent, {
       add: {
-        imports: [RouterTestingModule]
+        imports: [RouterModule]
       }
     });
     const fixture = TestBed.createComponent(AppComponent);

--- a/angular-standalone/base/src/app/app.component.spec.ts
+++ b/angular-standalone/base/src/app/app.component.spec.ts
@@ -1,14 +1,14 @@
 import { TestBed } from '@angular/core/testing';
-import { RouterModule } from '@angular/router';
+import { provideRouter } from '@angular/router';
 import { AppComponent } from './app.component';
 
 describe('AppComponent', () => {
-  it('should create the app', () => {
-    TestBed.overrideComponent(AppComponent, {
-      add: {
-        imports: [RouterModule]
-      }
-    });
+  it('should create the app', async () => {
+    await TestBed.configureTestingModule({
+      imports: [AppComponent],
+      providers: [provideRouter([])]
+    }).compileComponents();
+    
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.componentInstance;
     expect(app).toBeTruthy();

--- a/angular-standalone/official/list/src/app/app.component.spec.ts
+++ b/angular-standalone/official/list/src/app/app.component.spec.ts
@@ -1,16 +1,15 @@
 import { TestBed } from '@angular/core/testing';
-import { RouterModule } from '@angular/router';
+import { provideRouter } from '@angular/router';
 
 import { AppComponent } from './app.component';
 
 describe('AppComponent', () => {
 
   beforeEach(async () => {
-    TestBed.overrideComponent(AppComponent, {
-      add: {
-        imports: [RouterModule]
-      }
-    });
+    await TestBed.configureTestingModule({
+      imports: [AppComponent],
+      providers: [provideRouter([])]
+    }).compileComponents();
   });
 
   it('should create the app', () => {

--- a/angular-standalone/official/list/src/app/app.component.spec.ts
+++ b/angular-standalone/official/list/src/app/app.component.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
+import { RouterModule } from '@angular/router';
 
 import { AppComponent } from './app.component';
 
@@ -8,7 +8,7 @@ describe('AppComponent', () => {
   beforeEach(async () => {
     TestBed.overrideComponent(AppComponent, {
       add: {
-        imports: [RouterTestingModule]
+        imports: [RouterModule]
       }
     });
   });

--- a/angular-standalone/official/sidemenu/src/app/app.component.spec.ts
+++ b/angular-standalone/official/sidemenu/src/app/app.component.spec.ts
@@ -1,15 +1,14 @@
 import { TestBed } from '@angular/core/testing';
-import { RouterModule } from '@angular/router';
+import { provideRouter } from '@angular/router';
 
 import { AppComponent } from './app.component';
 
 describe('AppComponent', () => {
   beforeEach(async () => {
-    TestBed.overrideComponent(AppComponent, {
-      add: {
-        imports: [RouterModule]
-      }
-    });
+    await TestBed.configureTestingModule({
+      imports: [AppComponent],
+      providers: [provideRouter([])]
+    }).compileComponents();
   });
 
   it('should create the app', () => {

--- a/angular-standalone/official/sidemenu/src/app/app.component.spec.ts
+++ b/angular-standalone/official/sidemenu/src/app/app.component.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
+import { RouterModule } from '@angular/router';
 
 import { AppComponent } from './app.component';
 
@@ -7,7 +7,7 @@ describe('AppComponent', () => {
   beforeEach(async () => {
     TestBed.overrideComponent(AppComponent, {
       add: {
-        imports: [RouterTestingModule]
+        imports: [RouterModule]
       }
     });
   });

--- a/angular-standalone/official/sidemenu/src/app/folder/folder.page.spec.ts
+++ b/angular-standalone/official/sidemenu/src/app/folder/folder.page.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterModule } from '@angular/router';
+import { provideRouter } from '@angular/router';
 
 import { FolderPage } from './folder.page';
 
@@ -8,11 +8,10 @@ describe('FolderPage', () => {
   let fixture: ComponentFixture<FolderPage>;
 
   beforeEach(async () => {
-    TestBed.overrideComponent(FolderPage, {
-      add: {
-        imports: [RouterModule]
-      }
-    });
+    await TestBed.configureTestingModule({
+      imports: [FolderPage],
+      providers: [provideRouter([])]
+    }).compileComponents();
 
     fixture = TestBed.createComponent(FolderPage);
     component = fixture.componentInstance;

--- a/angular-standalone/official/sidemenu/src/app/folder/folder.page.spec.ts
+++ b/angular-standalone/official/sidemenu/src/app/folder/folder.page.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
+import { RouterModule } from '@angular/router';
 
 import { FolderPage } from './folder.page';
 
@@ -10,7 +10,7 @@ describe('FolderPage', () => {
   beforeEach(async () => {
     TestBed.overrideComponent(FolderPage, {
       add: {
-        imports: [RouterTestingModule]
+        imports: [RouterModule]
       }
     });
 

--- a/angular-standalone/official/tabs/src/app/tabs/tabs.page.spec.ts
+++ b/angular-standalone/official/tabs/src/app/tabs/tabs.page.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterModule } from '@angular/router';
+import { provideRouter } from '@angular/router';
 
 import { TabsPage } from './tabs.page';
 
@@ -8,11 +8,10 @@ describe('TabsPage', () => {
   let fixture: ComponentFixture<TabsPage>;
 
   beforeEach(async () => {
-    TestBed.overrideComponent(TabsPage, {
-      add: {
-        imports: [RouterModule]
-      }
-    });
+    await TestBed.configureTestingModule({
+      imports: [TabsPage],
+      providers: [provideRouter([])]
+    }).compileComponents();
   });
 
   beforeEach(() => {

--- a/angular-standalone/official/tabs/src/app/tabs/tabs.page.spec.ts
+++ b/angular-standalone/official/tabs/src/app/tabs/tabs.page.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
+import { RouterModule } from '@angular/router';
 
 import { TabsPage } from './tabs.page';
 
@@ -10,7 +10,7 @@ describe('TabsPage', () => {
   beforeEach(async () => {
     TestBed.overrideComponent(TabsPage, {
       add: {
-        imports: [RouterTestingModule]
+        imports: [RouterModule]
       }
     });
   });

--- a/angular/official/sidemenu/src/app/app.component.spec.ts
+++ b/angular/official/sidemenu/src/app/app.component.spec.ts
@@ -1,7 +1,7 @@
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
-import { RouterTestingModule } from '@angular/router/testing';
+import { RouterModule } from '@angular/router';
 
 import { AppComponent } from './app.component';
 
@@ -13,7 +13,7 @@ describe('AppComponent', () => {
     await TestBed.configureTestingModule({
       declarations: [AppComponent],
       schemas: [CUSTOM_ELEMENTS_SCHEMA],
-      imports: [RouterTestingModule.withRoutes([])],
+      imports: [RouterModule.forRoot([])],
     }).compileComponents();
   });
 


### PR DESCRIPTION
RouterTestingModule was deprecated in v17.3.0 of Angular and marked as deprecate here: https://github.com/angular/angular/pull/54466