### PR TITLE
fix: migrate sidemenu step color usage

### DIFF
--- a/angular-standalone/official/sidemenu/src/app/app.component.scss
+++ b/angular-standalone/official/sidemenu/src/app/app.component.scss
@@ -23,7 +23,7 @@ ion-menu.md ion-note {
 }
 
 ion-menu.md ion-list#inbox-list {
-  border-bottom: 1px solid var(--ion-color-step-150, #d7d8da);
+  border-bottom: 1px solid var(--ion-background-color-step-150, #d7d8da);
 }
 
 ion-menu.md ion-list#inbox-list ion-list-header {

--- a/angular/official/sidemenu/src/app/app.component.scss
+++ b/angular/official/sidemenu/src/app/app.component.scss
@@ -23,7 +23,7 @@ ion-menu.md ion-note {
 }
 
 ion-menu.md ion-list#inbox-list {
-  border-bottom: 1px solid var(--ion-color-step-150, #d7d8da);
+  border-bottom: 1px solid var(--ion-background-color-step-150, #d7d8da);
 }
 
 ion-menu.md ion-list#inbox-list ion-list-header {

--- a/react-vite/official/sidemenu/src/components/Menu.css
+++ b/react-vite/official/sidemenu/src/components/Menu.css
@@ -22,7 +22,7 @@ ion-menu.md ion-list-header, ion-menu.md ion-note {
 }
 
 ion-menu.md ion-list#inbox-list {
-  border-bottom: 1px solid var(--ion-color-step-150, #d7d8da);
+  border-bottom: 1px solid var(--ion-background-color-step-150, #d7d8da);
 }
 
 ion-menu.md ion-list#inbox-list ion-list-header {

--- a/vue-vite/official/sidemenu/src/App.vue
+++ b/vue-vite/official/sidemenu/src/App.vue
@@ -136,7 +136,7 @@ ion-menu.md ion-note {
 }
 
 ion-menu.md ion-list#inbox-list {
-  border-bottom: 1px solid var(--ion-color-step-150, #d7d8da);
+  border-bottom: 1px solid var(--ion-background-color-step-150, #d7d8da);
 }
 
 ion-menu.md ion-list#inbox-list ion-list-header {


### PR DESCRIPTION
The step color token used on the sidemenu app was never updated to use the latest syntax. As a result, the border in dark mode always showed as the light mode fallback.

| Before | After |
| - | - | 
| ![Screenshot 2024-04-29 at 9 44 52 AM](https://github.com/ionic-team/starters/assets/2721089/bc8d5b23-5ee9-4b91-b9ab-8bf3f1cb5efc) | ![Screenshot 2024-04-29 at 9 44 39 AM](https://github.com/ionic-team/starters/assets/2721089/84265e4e-c599-4815-9b18-77b35ac732d5) |
