### PR TITLE
chore(react-vite): pin stencil and ionic versions

### DIFF
--- a/react-vite/base/package.json
+++ b/react-vite/base/package.json
@@ -12,8 +12,9 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "@ionic/react": "^8.0.0",
-    "@ionic/react-router": "^8.0.0",
+    "@ionic/react": "8.2.2",
+    "@ionic/react-router": "8.2.2",
+    "@stencil/core": "4.18.3",
     "@types/react-router": "^5.1.20",
     "@types/react-router-dom": "^5.3.3",
     "ionicons": "^7.0.0",


### PR DESCRIPTION
The unit tests, `npm run test.unit` are failing on `react-vite` builds. This is happening from a release from Stencil. Until a fix is released, pinning the version will be a temporarily patch.