### PR TITLE
fix(react): update list starter for correct styles and back button text

### DIFF
--- a/react-vite/official/list/src/components/MessageListItem.css
+++ b/react-vite/official/list/src/components/MessageListItem.css
@@ -1,17 +1,19 @@
-ion-item {
+#message-list-item {
   --padding-start: 0;
   --inner-padding-end: 0;
 }
 
-ion-label {
+#message-list-item ion-label {
   margin-top: 12px;
   margin-bottom: 12px;
+
+  overflow: hidden;
 }
 
-ion-item h2 {
+#message-list-item ion-label h2 {
   font-weight: 600;
   margin: 0;
-  
+
   /**
    * With larger font scales
    * the date/time should wrap to the next
@@ -24,33 +26,31 @@ ion-item h2 {
   justify-content: space-between;
 }
 
-ion-item p {
-  text-overflow: ellipsis;
-  overflow: hidden;
+#message-list-item p {
   white-space: nowrap;
   width: 95%;
 }
 
-ion-item .date {
+#message-list-item .date {
   align-items: center;
   display: flex;
 }
 
-ion-item ion-icon {
+#message-list-item ion-icon {
   color: #c9c9ca;
 }
 
-ion-item ion-note {
+#message-list-item ion-note {
   font-size: 0.9375rem;
   margin-right: 8px;
   font-weight: normal;
 }
 
-ion-item ion-note.md {
+#message-list-item ion-note.md {
   margin-right: 14px;
 }
 
-.dot {
+#message-list-item .dot {
   display: block;
   height: 12px;
   width: 12px;
@@ -59,11 +59,6 @@ ion-item ion-note.md {
   margin: 16px 10px 16px 16px;
 }
 
-.dot-unread {
+#message-list-item .dot-unread {
   background: var(--ion-color-primary);
-}
-
-ion-footer ion-title {
-  font-size: 11px;
-  font-weight: normal;
 }

--- a/react-vite/official/list/src/components/MessageListItem.tsx
+++ b/react-vite/official/list/src/components/MessageListItem.tsx
@@ -12,7 +12,7 @@ interface MessageListItemProps {
 
 const MessageListItem: React.FC<MessageListItemProps> = ({ message }) => {
   return (
-    <IonItem routerLink={`/message/${message.id}`} detail={false}>
+    <IonItem id="message-list-item" routerLink={`/message/${message.id}`} detail={false}>
       <div slot="start" className="dot dot-unread"></div>
       <IonLabel className="ion-text-wrap">
         <h2>

--- a/react/official/list/src/pages/ViewMessage.tsx
+++ b/react/official/list/src/pages/ViewMessage.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useState } from 'react';
 import { Message, getMessage } from '../data/messages';
 import {
@@ -13,6 +12,7 @@ import {
   IonPage,
   IonToolbar,
   useIonViewWillEnter,
+  isPlatform
 } from '@ionic/react';
 import { personCircle } from 'ionicons/icons';
 import { useParams } from 'react-router';
@@ -27,12 +27,17 @@ function ViewMessage() {
     setMessage(msg);
   });
 
+  const getBackButtonText = () => {
+    const isIos = isPlatform('ios')
+    return isIos ? 'Inbox' : '';
+  };
+
   return (
     <IonPage id="view-message-page">
       <IonHeader translucent>
         <IonToolbar>
           <IonButtons slot="start">
-            <IonBackButton text="Inbox" defaultHref="/home"></IonBackButton>
+            <IonBackButton text={getBackButtonText()} defaultHref="/home"></IonBackButton>
           </IonButtons>
         </IonToolbar>
       </IonHeader>

--- a/react/official/list/src/pages/ViewMessage.tsx
+++ b/react/official/list/src/pages/ViewMessage.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { useState } from 'react';
 import { Message, getMessage } from '../data/messages';
 import {


### PR DESCRIPTION
The React list starter was not overriding the Ionic styles for label, resulting in it looking different compared to the Angular list starter. This updates the CSS to target an `IonItem` with an `id` so that the styles are properly overridden. Additionally, I updated the back button text for the `ViewMessage` view because it should only display on `ios` mode and it was displaying for `md`.

<table>
<thead>
<td>Before</td>
<td>After</td>
</thead>
<tbody>
<tr>
<td width="50%">
<img alt="before" src="https://github.com/user-attachments/assets/ae068989-0feb-4c41-b205-4b26e690ca59">
</td>
<td width="50%">
<img alt="after" src="https://github.com/user-attachments/assets/fca54569-b0ea-47f0-9ed6-9541641db691">
</td>
</tr>
<tr>
<td width="50%">
<img alt="before2" src="https://github.com/user-attachments/assets/afe2fc43-5e5e-492d-8424-320b5581c550">
</td>
<td width="50%">
<img alt="after2" src="https://github.com/user-attachments/assets/2e62f7d3-c53a-49a6-837e-9eb7f0658440">
</td>
</tr>
</table>
