### PR TITLE
fix(angular-standalone): prevent browser folder creation

### DIFF
--- a/angular-standalone/base/angular.json
+++ b/angular-standalone/base/angular.json
@@ -19,7 +19,8 @@
           "builder": "@angular-devkit/build-angular:application",
           "options": {
             "outputPath": {
-              "base": "www"
+              "base": "www",
+              "browser": ""
             },
             "index": "src/index.html",
             "polyfills": [


### PR DESCRIPTION
Angular standalone apps are creating the assets in a `browser` folder inside `www`, which is causing issues for Capacitor users as it expects the `index.html` to be at the root of the `www` folder.

This change prevents the creation of the `browser` folder.