### PR TITLE
feat: VS Code extension migration to WebNative.dev

### DIFF
--- a/angular-standalone/base/.vscode/extensions.json
+++ b/angular-standalone/base/.vscode/extensions.json
@@ -1,5 +1,5 @@
 {
     "recommendations": [
-      "ionic.ionic"
+       "Webnative.webnative"
     ]
 }

--- a/angular/base/.vscode/extensions.json
+++ b/angular/base/.vscode/extensions.json
@@ -1,5 +1,5 @@
 {
     "recommendations": [
-      "ionic.ionic"
+       "Webnative.webnative"
     ]
 }

--- a/react-vite/base/.vscode/extensions.json
+++ b/react-vite/base/.vscode/extensions.json
@@ -1,5 +1,5 @@
 {
     "recommendations": [
-        "ionic.ionic"
+        "Webnative.webnative"
     ]
 }

--- a/react/base/.vscode/extensions.json
+++ b/react/base/.vscode/extensions.json
@@ -1,5 +1,5 @@
 {
     "recommendations": [
-        "ionic.ionic"
+        "Webnative.webnative"
     ]
 }

--- a/vue-vite/base/.vscode/extensions.json
+++ b/vue-vite/base/.vscode/extensions.json
@@ -1,5 +1,5 @@
 {
     "recommendations": [
-        "ionic.ionic"
+        "Webnative.webnative"
     ]
 }

--- a/vue/base/.vscode/extensions.json
+++ b/vue/base/.vscode/extensions.json
@@ -1,5 +1,5 @@
 {
     "recommendations": [
-        "ionic.ionic"
+        "Webnative.webnative"
     ]
 }


### PR DESCRIPTION
This changes the recommended VS Code extension from Ionic to [WebNative.dev](https://webnative.dev/).