### PR TITLE
docs(many): switch text to "refer to"

### DIFF
--- a/angular/base/src/theme/variables.scss
+++ b/angular/base/src/theme/variables.scss
@@ -1,2 +1,2 @@
-// For information on how to create your own theme, please see:
+// For information on how to create your own theme, please refer to:
 // https://ionicframework.com/docs/theming/

--- a/react-vite/base/src/theme/variables.css
+++ b/react-vite/base/src/theme/variables.css
@@ -1,2 +1,2 @@
-/* For information on how to create your own theme, please see:
+/* For information on how to create your own theme, please refer to:
 http://ionicframework.com/docs/theming/ */

--- a/vue-vite/base/src/theme/variables.css
+++ b/vue-vite/base/src/theme/variables.css
@@ -1,2 +1,2 @@
-/* For information on how to create your own theme, please see:
+/* For information on how to create your own theme, please refer to:
 http://ionicframework.com/docs/theming/ */


### PR DESCRIPTION
Issue URL: N/A


## What is the current behavior?

Some areas do not match with a [previous change](https://github.com/ionic-team/starters/pull/1875/files#diff-f573f223ca043aebd37daeefd2fe062a9694fd5ba33355ce7a8da48de7b038efR1) that was done on certain sentences.

## What is the new behavior?

- Updated text to use "refer to" to match the previous change

## Does this introduce a breaking change?

- [ ] Yes
- [x] No


## Other information

N/A