### PR TITLE
test(angular): assert sidemenu routerLink binding instead of flaky rendered href

### DIFF
--- a/angular-standalone/official/sidemenu/src/app/app.component.spec.ts
+++ b/angular-standalone/official/sidemenu/src/app/app.component.spec.ts
@@ -1,5 +1,6 @@
 import { TestBed } from '@angular/core/testing';
-import { provideRouter } from '@angular/router';
+import { By } from '@angular/platform-browser';
+import { provideRouter, Router, RouterLink } from '@angular/router';
 
 import { AppComponent } from './app.component';
 
@@ -34,13 +35,16 @@ describe('AppComponent', () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
     const app = fixture.nativeElement;
-    const menuItems = app.querySelectorAll('ion-item');
-    expect(menuItems.length).toEqual(12);
-    expect(menuItems[0].getAttribute('href')).toEqual(
-      '/folder/inbox'
-    );
-    expect(menuItems[1].getAttribute('href')).toEqual(
-      '/folder/outbox'
-    );
+    expect(app.querySelectorAll('ion-item').length).toEqual(12);
+    // Ionic applies the rendered href through its own async write queue, so
+    // reading the DOM attribute is flaky (FW-6264). Assert the routerLink
+    // binding directly, which resolves synchronously.
+    const router = TestBed.inject(Router);
+    const links = fixture.debugElement
+      .queryAll(By.directive(RouterLink))
+      .map((el) => el.injector.get(RouterLink));
+    expect(links.length).toEqual(6);
+    expect(router.serializeUrl(links[0].urlTree!)).toEqual('/folder/inbox');
+    expect(router.serializeUrl(links[1].urlTree!)).toEqual('/folder/outbox');
   });
 });

--- a/angular/official/sidemenu/src/app/app.component.spec.ts
+++ b/angular/official/sidemenu/src/app/app.component.spec.ts
@@ -1,7 +1,8 @@
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
 
-import { RouterModule } from '@angular/router';
+import { Router, RouterLink, RouterModule } from '@angular/router';
 
 import { AppComponent } from './app.component';
 
@@ -38,10 +39,17 @@ describe('AppComponent', () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
     const app = fixture.nativeElement;
-    const menuItems = app.querySelectorAll('ion-item');
-    expect(menuItems.length).toEqual(12);
-    expect(menuItems[0].getAttribute('href')).toEqual('/folder/inbox');
-    expect(menuItems[1].getAttribute('href')).toEqual('/folder/outbox');
+    expect(app.querySelectorAll('ion-item').length).toEqual(12);
+    // Ionic applies the rendered href through its own async write queue, so
+    // reading the DOM attribute is flaky (FW-6264). Assert the routerLink
+    // binding directly, which resolves synchronously.
+    const router = TestBed.inject(Router);
+    const links = fixture.debugElement
+      .queryAll(By.directive(RouterLink))
+      .map((el) => el.injector.get(RouterLink));
+    expect(links.length).toEqual(6);
+    expect(router.serializeUrl(links[0].urlTree!)).toEqual('/folder/inbox');
+    expect(router.serializeUrl(links[1].urlTree!)).toEqual('/folder/outbox');
   });
 
 });


### PR DESCRIPTION
## What is the current behavior?

The sidemenu `should have urls` spec reads `ion-item.getAttribute('href')` right after a single `detectChanges()`. Ionic's `RouterLinkDelegate` applies that href through its own async (rAF-based) write queue, so the attribute is often still `null` when the assertion runs. The test fails intermittently, and it failed three times in a row on `main` after #1878 merged, which failed `verify-test` and skipped the `deploy` job, so the Angular dependency fix never shipped to the CDN. This is the flakiness tracked in FW-6264.

## What is the new behavior?

The test now asserts the `routerLink` binding directly through the `RouterLink` directive's `urlTree`, which resolves synchronously from the bound commands, so it no longer depends on when Ionic writes the rendered `href`. Applied to both the `angular` and `angular-standalone` sidemenu starters. I ran each 12 times locally and both were green every time; the old version flaked on roughly 40% of runs.

The non-standalone `should have menu labels` test stays `xit`'d. That one reads `ion-label` `textContent`, which is a separate Stencil slot-hydration timing issue, still owned by FW-6264.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

## Other information

Once this lands, the `deploy` job on `main` should pass and ship the #1878 dependency fix (FW-7584) to the CDN.