### PR TITLE
feat(angular): update lazy and standalone import paths

### DIFF
--- a/angular-standalone/base/package.json
+++ b/angular-standalone/base/package.json
@@ -19,7 +19,7 @@
     "@angular/forms": "22.0.1",
     "@angular/platform-browser": "22.0.1",
     "@angular/router": "22.0.1",
-    "@ionic/angular": "8.8.9-dev.11781098612.122c6758",
+    "@ionic/angular": "^8.8.14-dev.11783984044.10eaba06",
     "ionicons": "^7.0.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0"

--- a/angular-standalone/base/package.json
+++ b/angular-standalone/base/package.json
@@ -19,7 +19,7 @@
     "@angular/forms": "22.0.1",
     "@angular/platform-browser": "22.0.1",
     "@angular/router": "22.0.1",
-    "@ionic/angular": "^8.8.14-dev.11783984044.10eaba06",
+    "@ionic/angular": "8.8.14-dev.11783984044.10eaba06",
     "ionicons": "^7.0.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0"

--- a/angular-standalone/base/src/app/app.component.ts
+++ b/angular-standalone/base/src/app/app.component.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { IonApp } from '@ionic/angular/standalone';
+import { IonApp } from '@ionic/angular';
 
 @Component({
   selector: 'app-root',

--- a/angular-standalone/base/src/main.ts
+++ b/angular-standalone/base/src/main.ts
@@ -1,7 +1,7 @@
 import { provideZonelessChangeDetection } from '@angular/core';
 import { bootstrapApplication } from '@angular/platform-browser';
 import { RouteReuseStrategy, provideRouter, withComponentInputBinding, withPreloading, PreloadAllModules } from '@angular/router';
-import { IonicRouteStrategy, provideIonicAngular } from '@ionic/angular/standalone';
+import { IonicRouteStrategy, provideIonicAngular } from '@ionic/angular';
 
 import { routes } from './app/app.routes';
 import { AppComponent } from './app/app.component';

--- a/angular-standalone/official/blank/src/app/app.component.ts
+++ b/angular-standalone/official/blank/src/app/app.component.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { IonApp, IonRouterOutlet } from '@ionic/angular/standalone';
+import { IonApp, IonRouterOutlet } from '@ionic/angular';
 
 @Component({
   selector: 'app-root',

--- a/angular-standalone/official/blank/src/app/home/home.page.ts
+++ b/angular-standalone/official/blank/src/app/home/home.page.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { IonHeader, IonToolbar, IonTitle, IonContent } from '@ionic/angular/standalone';
+import { IonHeader, IonToolbar, IonTitle, IonContent } from '@ionic/angular';
 
 @Component({
   selector: 'app-home',

--- a/angular-standalone/official/list/src/app/app.component.ts
+++ b/angular-standalone/official/list/src/app/app.component.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { IonApp, IonRouterOutlet } from '@ionic/angular/standalone';
+import { IonApp, IonRouterOutlet } from '@ionic/angular';
 
 @Component({
   selector: 'app-root',

--- a/angular-standalone/official/list/src/app/home/home.page.ts
+++ b/angular-standalone/official/list/src/app/home/home.page.ts
@@ -1,5 +1,5 @@
 import { Component, inject } from '@angular/core';
-import { RefresherCustomEvent, IonHeader, IonToolbar, IonTitle, IonContent, IonRefresher, IonRefresherContent, IonList } from '@ionic/angular/standalone';
+import { RefresherCustomEvent, IonHeader, IonToolbar, IonTitle, IonContent, IonRefresher, IonRefresherContent, IonList } from '@ionic/angular';
 import { MessageComponent } from '../message/message.component';
 
 import { DataService } from '../services/data.service';

--- a/angular-standalone/official/list/src/app/message/message.component.ts
+++ b/angular-standalone/official/list/src/app/message/message.component.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, Component, inject, input } from '@angular/core';
 import { RouterLink } from '@angular/router';
-import { Platform, IonItem, IonLabel, IonNote, IonIcon } from '@ionic/angular/standalone';
+import { Platform, IonItem, IonLabel, IonNote, IonIcon } from '@ionic/angular';
 import { addIcons } from 'ionicons';
 import { chevronForward } from 'ionicons/icons';
 import { Message } from '../services/data.service';

--- a/angular-standalone/official/list/src/app/view-message/view-message.page.ts
+++ b/angular-standalone/official/list/src/app/view-message/view-message.page.ts
@@ -1,5 +1,5 @@
 import { Component, computed, inject, input } from '@angular/core';
-import { Platform, IonHeader, IonToolbar, IonButtons, IonBackButton, IonContent, IonItem, IonIcon, IonLabel, IonNote } from '@ionic/angular/standalone';
+import { Platform, IonHeader, IonToolbar, IonButtons, IonBackButton, IonContent, IonItem, IonIcon, IonLabel, IonNote } from '@ionic/angular';
 import { addIcons } from 'ionicons';
 import { personCircle } from 'ionicons/icons';
 import { DataService } from '../services/data.service';

--- a/angular-standalone/official/sidemenu/src/app/app.component.ts
+++ b/angular-standalone/official/sidemenu/src/app/app.component.ts
@@ -1,7 +1,7 @@
 
 import { Component } from '@angular/core';
 import { RouterLink, RouterLinkActive } from '@angular/router';
-import { IonApp, IonSplitPane, IonMenu, IonContent, IonList, IonListHeader, IonNote, IonMenuToggle, IonItem, IonIcon, IonLabel, IonRouterOutlet, IonRouterLink } from '@ionic/angular/standalone';
+import { IonApp, IonSplitPane, IonMenu, IonContent, IonList, IonListHeader, IonNote, IonMenuToggle, IonItem, IonIcon, IonLabel, IonRouterOutlet, IonRouterLink } from '@ionic/angular';
 import { addIcons } from 'ionicons';
 import { mailOutline, mailSharp, paperPlaneOutline, paperPlaneSharp, heartOutline, heartSharp, archiveOutline, archiveSharp, trashOutline, trashSharp, warningOutline, warningSharp, bookmarkOutline, bookmarkSharp } from 'ionicons/icons';
 

--- a/angular-standalone/official/sidemenu/src/app/folder/folder.page.ts
+++ b/angular-standalone/official/sidemenu/src/app/folder/folder.page.ts
@@ -1,5 +1,5 @@
 import { Component, input } from '@angular/core';
-import { IonHeader, IonToolbar, IonButtons, IonMenuButton, IonTitle, IonContent } from '@ionic/angular/standalone';
+import { IonHeader, IonToolbar, IonButtons, IonMenuButton, IonTitle, IonContent } from '@ionic/angular';
 
 @Component({
   selector: 'app-folder',

--- a/angular-standalone/official/tabs/src/app/app.component.ts
+++ b/angular-standalone/official/tabs/src/app/app.component.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { IonApp, IonRouterOutlet } from '@ionic/angular/standalone';
+import { IonApp, IonRouterOutlet } from '@ionic/angular';
 
 @Component({
   selector: 'app-root',

--- a/angular-standalone/official/tabs/src/app/tab1/tab1.page.ts
+++ b/angular-standalone/official/tabs/src/app/tab1/tab1.page.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { IonHeader, IonToolbar, IonTitle, IonContent } from '@ionic/angular/standalone';
+import { IonHeader, IonToolbar, IonTitle, IonContent } from '@ionic/angular';
 import { ExploreContainerComponent } from '../explore-container/explore-container.component';
 
 @Component({

--- a/angular-standalone/official/tabs/src/app/tab2/tab2.page.ts
+++ b/angular-standalone/official/tabs/src/app/tab2/tab2.page.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { IonHeader, IonToolbar, IonTitle, IonContent } from '@ionic/angular/standalone';
+import { IonHeader, IonToolbar, IonTitle, IonContent } from '@ionic/angular';
 import { ExploreContainerComponent } from '../explore-container/explore-container.component';
 
 @Component({

--- a/angular-standalone/official/tabs/src/app/tab3/tab3.page.ts
+++ b/angular-standalone/official/tabs/src/app/tab3/tab3.page.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { IonHeader, IonToolbar, IonTitle, IonContent } from '@ionic/angular/standalone';
+import { IonHeader, IonToolbar, IonTitle, IonContent } from '@ionic/angular';
 import { ExploreContainerComponent } from '../explore-container/explore-container.component';
 
 @Component({

--- a/angular-standalone/official/tabs/src/app/tabs/tabs.page.ts
+++ b/angular-standalone/official/tabs/src/app/tabs/tabs.page.ts
@@ -1,5 +1,5 @@
 import { Component, EnvironmentInjector, inject } from '@angular/core';
-import { IonTabs, IonTabBar, IonTabButton, IonIcon, IonLabel } from '@ionic/angular/standalone';
+import { IonTabs, IonTabBar, IonTabButton, IonIcon, IonLabel } from '@ionic/angular';
 import { addIcons } from 'ionicons';
 import { triangle, ellipse, square } from 'ionicons/icons';
 

--- a/angular/base/.vscode/settings.json
+++ b/angular/base/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-  "typescript.preferences.autoImportFileExcludePatterns": ["@ionic/angular/common", "@ionic/angular/standalone"]
+  "typescript.preferences.autoImportFileExcludePatterns": ["@ionic/angular/common", "@ionic/angular"]
 }

--- a/angular/base/package.json
+++ b/angular/base/package.json
@@ -20,7 +20,7 @@
     "@angular/platform-browser": "22.0.1",
     "@angular/platform-browser-dynamic": "22.0.1",
     "@angular/router": "22.0.1",
-    "@ionic/angular": "8.8.9-dev.11781098612.122c6758",
+    "@ionic/angular": "^8.8.14-dev.11783984044.10eaba06",
     "ionicons": "^7.0.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0"

--- a/angular/base/package.json
+++ b/angular/base/package.json
@@ -20,7 +20,7 @@
     "@angular/platform-browser": "22.0.1",
     "@angular/platform-browser-dynamic": "22.0.1",
     "@angular/router": "22.0.1",
-    "@ionic/angular": "^8.8.14-dev.11783984044.10eaba06",
+    "@ionic/angular": "8.8.14-dev.11783984044.10eaba06",
     "ionicons": "^7.0.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0"

--- a/angular/base/src/app/app.module.ts
+++ b/angular/base/src/app/app.module.ts
@@ -2,7 +2,7 @@ import { NgModule, provideZonelessChangeDetection } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { RouteReuseStrategy } from '@angular/router';
 
-import { IonicModule, IonicRouteStrategy } from '@ionic/angular';
+import { IonicModule, IonicRouteStrategy } from '@ionic/angular/lazy';
 
 import { AppComponent } from './app.component';
 

--- a/angular/official/blank/src/app/app.module.ts
+++ b/angular/official/blank/src/app/app.module.ts
@@ -2,7 +2,7 @@ import { NgModule, provideZonelessChangeDetection } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { RouteReuseStrategy } from '@angular/router';
 
-import { IonicModule, IonicRouteStrategy } from '@ionic/angular';
+import { IonicModule, IonicRouteStrategy } from '@ionic/angular/lazy';
 
 import { AppComponent } from './app.component';
 import { AppRoutingModule } from './app-routing.module';

--- a/angular/official/blank/src/app/home/home.module.ts
+++ b/angular/official/blank/src/app/home/home.module.ts
@@ -1,6 +1,6 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { IonicModule } from '@ionic/angular';
+import { IonicModule } from '@ionic/angular/lazy';
 import { FormsModule } from '@angular/forms';
 import { HomePage } from './home.page';
 

--- a/angular/official/blank/src/app/home/home.page.spec.ts
+++ b/angular/official/blank/src/app/home/home.page.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { IonicModule } from '@ionic/angular';
+import { IonicModule } from '@ionic/angular/lazy';
 
 import { HomePage } from './home.page';
 

--- a/angular/official/list/src/app/app.module.ts
+++ b/angular/official/list/src/app/app.module.ts
@@ -2,7 +2,7 @@ import { NgModule, provideZonelessChangeDetection } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { RouteReuseStrategy } from '@angular/router';
 
-import { IonicModule, IonicRouteStrategy } from '@ionic/angular';
+import { IonicModule, IonicRouteStrategy } from '@ionic/angular/lazy';
 
 import { AppComponent } from './app.component';
 import { AppRoutingModule } from './app-routing.module';

--- a/angular/official/list/src/app/home/home.module.ts
+++ b/angular/official/list/src/app/home/home.module.ts
@@ -1,6 +1,6 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { IonicModule } from '@ionic/angular';
+import { IonicModule } from '@ionic/angular/lazy';
 import { FormsModule } from '@angular/forms';
 
 import { HomePage } from './home.page';

--- a/angular/official/list/src/app/home/home.page.ts
+++ b/angular/official/list/src/app/home/home.page.ts
@@ -1,5 +1,5 @@
 import { Component, inject } from '@angular/core';
-import { RefresherCustomEvent } from '@ionic/angular';
+import { RefresherCustomEvent } from '@ionic/angular/lazy';
 
 import { DataService } from '../services/data.service';
 

--- a/angular/official/list/src/app/message/message.component.spec.ts
+++ b/angular/official/list/src/app/message/message.component.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterModule } from '@angular/router';
-import { IonicModule } from '@ionic/angular';
+import { IonicModule } from '@ionic/angular/lazy';
 
 import { MessageComponent } from './message.component';
 

--- a/angular/official/list/src/app/message/message.component.ts
+++ b/angular/official/list/src/app/message/message.component.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectionStrategy, Component, inject, input } from '@angular/core';
-import { Platform } from '@ionic/angular';
+import { Platform } from '@ionic/angular/lazy';
 import { Message } from '../services/data.service';
 
 @Component({

--- a/angular/official/list/src/app/message/message.module.ts
+++ b/angular/official/list/src/app/message/message.module.ts
@@ -3,7 +3,7 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
 
-import { IonicModule } from '@ionic/angular';
+import { IonicModule } from '@ionic/angular/lazy';
 
 import { MessageComponent } from './message.component';
 

--- a/angular/official/list/src/app/view-message/view-message.module.ts
+++ b/angular/official/list/src/app/view-message/view-message.module.ts
@@ -3,7 +3,7 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ViewMessagePage } from './view-message.page';
 
-import { IonicModule } from '@ionic/angular';
+import { IonicModule } from '@ionic/angular/lazy';
 
 import { ViewMessagePageRoutingModule } from './view-message-routing.module';
 

--- a/angular/official/list/src/app/view-message/view-message.page.spec.ts
+++ b/angular/official/list/src/app/view-message/view-message.page.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { IonicModule } from '@ionic/angular';
+import { IonicModule } from '@ionic/angular/lazy';
 import { RouterModule } from '@angular/router';
 
 import { ViewMessagePageRoutingModule } from './view-message-routing.module';

--- a/angular/official/list/src/app/view-message/view-message.page.ts
+++ b/angular/official/list/src/app/view-message/view-message.page.ts
@@ -1,5 +1,5 @@
 import { Component, computed, inject, input } from '@angular/core';
-import { Platform } from '@ionic/angular';
+import { Platform } from '@ionic/angular/lazy';
 import { DataService } from '../services/data.service';
 
 @Component({

--- a/angular/official/sidemenu/src/app/app.component.spec.ts
+++ b/angular/official/sidemenu/src/app/app.component.spec.ts
@@ -3,7 +3,7 @@ import { TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
 import { Router, RouterLink, RouterModule } from '@angular/router';
-import { IonicModule } from '@ionic/angular';
+import { IonicModule } from '@ionic/angular/lazy';
 
 import { AppComponent } from './app.component';
 

--- a/angular/official/sidemenu/src/app/app.module.ts
+++ b/angular/official/sidemenu/src/app/app.module.ts
@@ -2,7 +2,7 @@ import { NgModule, provideZonelessChangeDetection } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { RouteReuseStrategy } from '@angular/router';
 
-import { IonicModule, IonicRouteStrategy } from '@ionic/angular';
+import { IonicModule, IonicRouteStrategy } from '@ionic/angular/lazy';
 
 import { AppComponent } from './app.component';
 import { AppRoutingModule } from './app-routing.module';

--- a/angular/official/sidemenu/src/app/folder/folder.module.ts
+++ b/angular/official/sidemenu/src/app/folder/folder.module.ts
@@ -2,7 +2,7 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 
-import { IonicModule } from '@ionic/angular';
+import { IonicModule } from '@ionic/angular/lazy';
 
 import { FolderPageRoutingModule } from './folder-routing.module';
 

--- a/angular/official/sidemenu/src/app/folder/folder.page.spec.ts
+++ b/angular/official/sidemenu/src/app/folder/folder.page.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterModule } from '@angular/router';
-import { IonicModule } from '@ionic/angular';
+import { IonicModule } from '@ionic/angular/lazy';
 
 import { FolderPage } from './folder.page';
 

--- a/angular/official/tabs/src/app/app.module.ts
+++ b/angular/official/tabs/src/app/app.module.ts
@@ -2,7 +2,7 @@ import { NgModule, provideZonelessChangeDetection } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { RouteReuseStrategy } from '@angular/router';
 
-import { IonicModule, IonicRouteStrategy } from '@ionic/angular';
+import { IonicModule, IonicRouteStrategy } from '@ionic/angular/lazy';
 
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';

--- a/angular/official/tabs/src/app/explore-container/explore-container.component.spec.ts
+++ b/angular/official/tabs/src/app/explore-container/explore-container.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { IonicModule } from '@ionic/angular';
+import { IonicModule } from '@ionic/angular/lazy';
 
 import { ExploreContainerComponent } from './explore-container.component';
 

--- a/angular/official/tabs/src/app/explore-container/explore-container.module.ts
+++ b/angular/official/tabs/src/app/explore-container/explore-container.module.ts
@@ -2,7 +2,7 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 
-import { IonicModule } from '@ionic/angular';
+import { IonicModule } from '@ionic/angular/lazy';
 
 import { ExploreContainerComponent } from './explore-container.component';
 

--- a/angular/official/tabs/src/app/tab1/tab1.module.ts
+++ b/angular/official/tabs/src/app/tab1/tab1.module.ts
@@ -1,4 +1,4 @@
-import { IonicModule } from '@ionic/angular';
+import { IonicModule } from '@ionic/angular/lazy';
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';

--- a/angular/official/tabs/src/app/tab2/tab2.module.ts
+++ b/angular/official/tabs/src/app/tab2/tab2.module.ts
@@ -1,4 +1,4 @@
-import { IonicModule } from '@ionic/angular';
+import { IonicModule } from '@ionic/angular/lazy';
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';

--- a/angular/official/tabs/src/app/tab3/tab3.module.ts
+++ b/angular/official/tabs/src/app/tab3/tab3.module.ts
@@ -1,4 +1,4 @@
-import { IonicModule } from '@ionic/angular';
+import { IonicModule } from '@ionic/angular/lazy';
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';

--- a/angular/official/tabs/src/app/tabs/tabs.module.ts
+++ b/angular/official/tabs/src/app/tabs/tabs.module.ts
@@ -1,4 +1,4 @@
-import { IonicModule } from '@ionic/angular';
+import { IonicModule } from '@ionic/angular/lazy';
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Ionic Framework v9 makes standalone components the default for Angular and changes the import paths: `@ionic/angular` -> `@ionic/angular/lazy` and `@ionic/angular/standalone` -> `@ionic/angular`. This PR updates the starter apps to use these new import paths.

## Change Type
- [ ] Fix
- [X] Feature
- [ ] Refactor
- [ ] Breaking Change
- [ ] Documentation
- [ ] Other (CI, chores, etc.)

## Platforms Affected
- [X] Android
- [X] iOS
- [X] Web

## Notes / Comments
<!--- Put anything else here that would be good for us to know! -->
The `@ionic/angular` dev build version specified in `package.json` has been bumped to a build with the import path updates. These will need to be changed to a 9.x build before merging major-9.0 branch into main.