### PR TITLE
fix(angular): keep ng generate working with angular-toolkit 13

### DIFF
--- a/angular-standalone/base/angular.json
+++ b/angular-standalone/base/angular.json
@@ -119,10 +119,12 @@
   },
   "schematics": {
     "@ionic/angular-toolkit:component": {
-      "styleext": "scss"
+      "styleext": "scss",
+      "standalone": true
     },
     "@ionic/angular-toolkit:page": {
-      "styleext": "scss"
+      "styleext": "scss",
+      "standalone": true
     },
     "@angular-eslint/schematics:application": {
       "setParserOptionsProject": true

--- a/angular-standalone/base/package.json
+++ b/angular-standalone/base/package.json
@@ -29,7 +29,7 @@
     "@angular/cli": "22.0.1",
     "@angular/compiler-cli": "22.0.1",
     "@angular/language-service": "22.0.1",
-    "@ionic/angular-toolkit": "^12.3.0",
+    "@ionic/angular-toolkit": "^13.0.0",
     "angular-eslint": "22.0.0",
     "eslint": "^9.16.0",
     "jsdom": "^26.0.0",

--- a/angular/base/angular.json
+++ b/angular/base/angular.json
@@ -124,10 +124,12 @@
   },
   "schematics": {
     "@ionic/angular-toolkit:component": {
-      "styleext": "scss"
+      "styleext": "scss",
+      "standalone": false
     },
     "@ionic/angular-toolkit:page": {
-      "styleext": "scss"
+      "styleext": "scss",
+      "standalone": false
     }
   }
 }

--- a/angular/base/package.json
+++ b/angular/base/package.json
@@ -30,7 +30,7 @@
     "@angular/cli": "22.0.1",
     "@angular/compiler-cli": "22.0.1",
     "@angular/language-service": "22.0.1",
-    "@ionic/angular-toolkit": "^12.3.0",
+    "@ionic/angular-toolkit": "^13.0.0",
     "angular-eslint": "22.0.0",
     "eslint": "^9.16.0",
     "jsdom": "^26.0.0",


### PR DESCRIPTION
`@ionic/angular-toolkit@13.0.0` is out. Both Angular starters need it, and the NgModule starter needs one extra change to survive a default that moved.
